### PR TITLE
Package Surface skill installs for Codex and Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ npm install -g surface-cli
 surface --help
 ```
 
-Then install the skill for the agent you use.
+Then install the skill for the agent you use. The npm package includes the
+matching Surface skill file, and `surface skill install` copies it into the
+agent's user skill directory.
 
 ### OpenClaw
 
@@ -55,12 +57,11 @@ If `openclaw skills check` reports the `surface` binary as missing, run
 
 ### Codex
 
-Codex reads user skills from `~/.agents/skills`:
+Codex reads user skills from `~/.codex/skills`:
 
 ```bash
-mkdir -p ~/.agents/skills/surface-cli
-curl -fsSL https://raw.githubusercontent.com/VishalJ99/surface-cli/main/skills/surface-cli/SKILL.md \
-  -o ~/.agents/skills/surface-cli/SKILL.md
+npm install -g surface-cli
+surface skill install codex
 ```
 
 Restart Codex if the skill does not appear immediately. Codex can invoke it
@@ -71,13 +72,19 @@ automatically from the description, or you can mention `$surface-cli`.
 Claude Code reads personal skills from `~/.claude/skills`:
 
 ```bash
-mkdir -p ~/.claude/skills/surface-cli
-curl -fsSL https://raw.githubusercontent.com/VishalJ99/surface-cli/main/skills/surface-cli/SKILL.md \
-  -o ~/.claude/skills/surface-cli/SKILL.md
+npm install -g surface-cli
+surface skill install claude-code
 ```
 
 Claude Code exposes the skill as `/surface-cli` and may also load it
 automatically when the task matches the skill description.
+
+To install both user skills on the same machine:
+
+```bash
+npm install -g surface-cli
+surface skill install all
+```
 
 ## Setup
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -9,6 +9,7 @@ Define the public Surface CLI commands and their machine-readable JSON output.
 - `surface account`
 - `surface auth`
 - `surface session`
+- `surface skill`
 - `surface mail`
 - `surface attachment`
 - `surface cache`
@@ -25,6 +26,7 @@ Define the public Surface CLI commands and their machine-readable JSON output.
 - `surface auth login <account> [--remote-host <host>]`
 - `surface auth status [account]`
 - `surface auth logout <account>`
+- `surface skill install <codex|claude-code|all>`
 
 Account identity notes:
 
@@ -105,6 +107,33 @@ Example remote auth login result:
     "status": "authenticated",
     "detail": "Authenticated as you@example.com."
   }
+}
+```
+
+### Agent Skill Install
+
+- `surface skill install codex` copies the bundled Surface skill to
+  `~/.codex/skills/surface-cli/SKILL.md`
+- `surface skill install claude-code` copies the bundled Surface skill to
+  `~/.claude/skills/surface-cli/SKILL.md`
+- `surface skill install all` installs both copies
+- `surface skill install claude` is accepted as an alias for `claude-code`
+
+Example skill install result:
+
+```json
+{
+  "schema_version": "1",
+  "command": "skill-install",
+  "target": "codex",
+  "installed": [
+    {
+      "agent": "codex",
+      "skill": "surface-cli",
+      "source": "/opt/homebrew/lib/node_modules/surface-cli/skills/surface-cli/SKILL.md",
+      "path": "/Users/example/.codex/skills/surface-cli/SKILL.md"
+    }
+  ]
 }
 ```
 

--- a/docs/decisions/0037-skill-install-command-installs-bundled-agent-skills.md
+++ b/docs/decisions/0037-skill-install-command-installs-bundled-agent-skills.md
@@ -1,0 +1,51 @@
+# ADR 0037: Skill Install Command Installs Bundled Agent Skills
+
+## Status
+
+Accepted
+
+## Context
+
+Surface has two installation surfaces:
+
+- the npm package, which installs the `surface` CLI binary
+- the agent skill, which teaches Codex, Claude Code, or OpenClaw when and how to use the CLI
+
+OpenClaw has ClawHub, but Codex and Claude Code users previously had to curl
+`skills/surface-cli/SKILL.md` from the repository. That made the install path
+depend on mutable `main` branch contents and could install skill text that did
+not match the npm package version.
+
+## Decision
+
+The npm package includes `skills/surface-cli/SKILL.md`.
+
+Surface exposes:
+
+```bash
+surface skill install codex
+surface skill install claude-code
+surface skill install all
+```
+
+`claude` is accepted as an alias for `claude-code`.
+
+The command copies the bundled skill into the default user skill directory for
+the target agent:
+
+- Codex: `~/.codex/skills/surface-cli/SKILL.md`
+- Claude Code: `~/.claude/skills/surface-cli/SKILL.md`
+
+The command returns a machine-readable `skill-install` envelope listing the
+source and destination paths for each installed copy.
+
+## Consequences
+
+- `npm install -g surface-cli` plus `surface skill install <target>` is enough
+  to install matching CLI and skill content for Codex or Claude Code.
+- Users no longer need to curl a raw GitHub URL for normal Codex or Claude Code
+  setup.
+- Release verification must include `npm pack --dry-run` to confirm the skill
+  file is included in the npm payload.
+- ClawHub remains the OpenClaw distribution path; this command is for local user
+  skill installs.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -58,3 +58,4 @@ Use zero-padded sequential numbers:
 - `0034-default-account-transport-from-provider.md`
 - `0035-use-gpt-5-4-mini-as-default-openrouter-summarizer.md`
 - `0036-html-hyperlinks-are-preserved-inline-in-body-text.md`
+- `0037-skill-install-command-installs-bundled-agent-skills.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surface-cli",
-  "version": "0.3.2",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surface-cli",
-      "version": "0.3.2",
+      "version": "0.3.9",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surface-cli",
-  "version": "0.3.2",
+  "version": "0.3.9",
   "description": "A lean, local-first mail CLI for Gmail and Outlook with a JSON-first contract for automation.",
   "homepage": "https://github.com/VishalJ99/surface-cli",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "gmail",
     "outlook",
     "automation",
-    "openclaw"
+    "openclaw",
+    "codex",
+    "claude-code"
   ],
   "type": "module",
   "bin": {
@@ -27,6 +29,7 @@
   },
   "files": [
     "dist",
+    "skills",
     "README.md"
   ],
   "scripts": {

--- a/skills/surface-cli/SKILL.md
+++ b/skills/surface-cli/SKILL.md
@@ -48,6 +48,14 @@ surface account list
 surface auth status
 ```
 
+If the user asks to install the Surface skill for another agent on the same machine, use:
+
+```bash
+surface skill install codex
+surface skill install claude-code
+surface skill install all
+```
+
 ## Account Setup
 
 Add an account:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,11 @@ import { writeJson } from "./lib/json.js";
 import { toPublicThread } from "./lib/public-mail.js";
 import { runRemoteAuthLogin } from "./lib/remote-auth.js";
 import { loadStoredThread, threadHasReadableCache } from "./lib/stored-mail.js";
+import {
+  expandSkillInstallTargets,
+  installSurfaceSkill,
+  parseSkillInstallTarget,
+} from "./lib/skill-install.js";
 import { nowIsoUtc } from "./lib/time.js";
 import { resolveProviderAdapter } from "./providers/index.js";
 import { createAccountRuntimeContext, createRuntimeContext } from "./runtime.js";
@@ -212,6 +217,25 @@ program
   .description("Multi-provider mail CLI for Surface.")
   .showHelpAfterError()
   .addOption(new Option("--config <path>", "Config file path").env("SURFACE_CONFIG_PATH"));
+
+const skillCommand = program.command("skill").description("Install Surface agent skills.");
+
+skillCommand
+  .command("install")
+  .argument("<target>", "Agent target: codex, claude-code, or all")
+  .action(async (targetValue: string) => {
+    const target = parseSkillInstallTarget(targetValue);
+    const installed = [];
+    for (const installTarget of expandSkillInstallTargets(target)) {
+      installed.push(await installSurfaceSkill(installTarget));
+    }
+    writeJson({
+      schema_version: "1",
+      command: "skill-install",
+      target,
+      installed,
+    });
+  });
 
 const accountCommand = program.command("account").description("Manage Surface accounts.");
 

--- a/src/lib/skill-install.ts
+++ b/src/lib/skill-install.ts
@@ -1,0 +1,78 @@
+import { copyFile, mkdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SurfaceError } from "./errors.js";
+
+export type SkillInstallTarget = "codex" | "claude-code";
+
+export interface SkillInstallResult {
+  agent: SkillInstallTarget;
+  skill: "surface-cli";
+  source: string;
+  path: string;
+}
+
+const SKILL_NAME = "surface-cli";
+
+function packageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+}
+
+export function bundledSkillPath(): string {
+  return join(packageRoot(), "skills", SKILL_NAME, "SKILL.md");
+}
+
+export function defaultSkillDestination(target: SkillInstallTarget): string {
+  switch (target) {
+    case "codex":
+      return join(homedir(), ".codex", "skills", SKILL_NAME, "SKILL.md");
+    case "claude-code":
+      return join(homedir(), ".claude", "skills", SKILL_NAME, "SKILL.md");
+  }
+}
+
+export function parseSkillInstallTarget(value: string): SkillInstallTarget | "all" {
+  switch (value) {
+    case "codex":
+      return "codex";
+    case "claude":
+    case "claude-code":
+      return "claude-code";
+    case "all":
+      return "all";
+    default:
+      throw new SurfaceError(
+        "invalid_argument",
+        `Expected skill install target to be one of: codex, claude-code, all. Received '${value}'.`,
+      );
+  }
+}
+
+export function expandSkillInstallTargets(target: SkillInstallTarget | "all"): SkillInstallTarget[] {
+  return target === "all" ? ["codex", "claude-code"] : [target];
+}
+
+export async function installSurfaceSkill(target: SkillInstallTarget): Promise<SkillInstallResult> {
+  const source = bundledSkillPath();
+  try {
+    await stat(source);
+  } catch {
+    throw new SurfaceError(
+      "not_found",
+      `Bundled Surface skill was not found at '${source}'. Reinstall surface-cli or install the skill from GitHub.`,
+    );
+  }
+
+  const destination = defaultSkillDestination(target);
+  await mkdir(dirname(destination), { recursive: true });
+  await copyFile(source, destination);
+
+  return {
+    agent: target,
+    skill: SKILL_NAME,
+    source,
+    path: destination,
+  };
+}


### PR DESCRIPTION
PER-251

## Summary
- add surface skill install codex / claude-code / all to copy the bundled Surface skill into Codex and Claude Code user skill directories
- include skills/surface-cli/SKILL.md in the npm package payload
- update README, CLI contract, skill text, and ADR 0039 for the new install path
- bump package metadata to 0.3.9 so npm and ClawHub can advance together

## Verification
- npm run check from clean detached worktree
- npm run build from clean detached worktree
- temp-HOME smoke: node dist/cli.js skill install all copied both Codex and Claude Code skills byte-for-byte
- npm pack --dry-run --json includes skills/surface-cli/SKILL.md

## Release note
- npm publish attempted from clean worktree but blocked by npm auth: npm whoami returns E401 Unauthorized.
- Publish npm first, then publish ClawHub skill 0.3.9.
