### PR TITLE
Add generic IMAP and SMTP provider support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,30 @@
 # AGENTS.md
 
+## User Environment
+
+This Codex session runs headlessly by default. Browser or desktop windows may exist but report
+zero-sized or unshareable bounds until the display is explicitly woken.
+
+When a task needs a headful browser or visible desktop UI, wake the screen first and use local
+Peekaboo capture/input with `--no-remote`. The known working pattern is:
+
+```bash
+/usr/bin/caffeinate -d -u -t 20 >/dev/null 2>&1 & sleep 2
+/opt/homebrew/bin/peekaboo see --mode screen --screen-index 0 --no-remote --capture-engine cg --json
+```
+
+Before clicks or typing, keep the display awake long enough for the action:
+
+```bash
+/usr/bin/caffeinate -d -u -t 45 >/dev/null 2>&1 & sleep 1
+/opt/homebrew/bin/peekaboo click --snapshot <snapshot-id> --id <element-id> --no-remote --input-strategy synthFirst --json
+/opt/homebrew/bin/peekaboo type --text '<text>' --return --delay 40 --profile linear --no-remote --input-strategy synthFirst --json
+```
+
+Do not ask the user to paste secrets into chat. If a password has to be typed into a headful UI,
+read it from an approved local private file or secret source and type it directly without printing
+it.
+
 ## Purpose
 
 Surface CLI is a contract-first mail CLI for multi-provider, multi-account email.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Surface CLI
 
-Outlook and Gmail from one local, JSON-first mail CLI.
+Gmail, Outlook, and generic IMAP from one local, JSON-first mail CLI.
 
 Surface solves the annoying mail automation case: you have a school or work
 Microsoft 365 account, IMAP is disabled, Graph app permissions need tenant admin
@@ -14,7 +14,7 @@ CLI for that mailbox.
 Surface is especially useful for coding agents and personal assistants because it
 keeps mail work compact:
 
-- one CLI contract for Gmail and Outlook
+- one CLI contract for Gmail, Outlook, and generic IMAP
 - multi-account support with stable account names
 - stable `thread_ref`, `message_ref`, `attachment_id`, and `session_id` values
 - thread-first `search` and `fetch-unread` results
@@ -30,7 +30,7 @@ Surface cannot override that policy.
 
 ## Fast Install
 
-Surface requires Node.js 20 or newer.
+Surface requires Node.js 20.19.0 or newer.
 
 Install the CLI first:
 
@@ -283,6 +283,7 @@ Surface v1 supports:
 
 - Gmail via Google APIs
 - Outlook via Outlook Web and Playwright
+- generic IMAP/SMTP for providers that expose mail server settings
 - account add/list/remove
 - auth login/status/logout
 - account-owner identity for summaries

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Add the accounts you want Surface to manage:
 ```bash
 surface account add uni --provider outlook --email you@school.edu
 surface account add personal --provider gmail --email you@gmail.com
+surface account add gmx --provider imap --email you@gmx.com
 surface account list
 ```
 
@@ -121,6 +122,35 @@ complete your normal Microsoft sign-in flow.
 For Gmail, `surface auth login <account>` uses a Google desktop OAuth client and
 stores the refresh token under `~/.surface-cli/auth/<account_id>/`. Place the
 client secret at `./client_secret.json` or set `SURFACE_GMAIL_CLIENT_SECRET_FILE`.
+
+For generic IMAP/SMTP, `provider=imap` uses the provider's mail server settings
+directly. It does not need a Google Cloud project, OAuth client JSON, Microsoft
+Graph app registration, or browser automation. It does need IMAP settings, SMTP
+settings, a username, and a mailbox or app password from a local secret source.
+
+GMX example:
+
+```bash
+surface auth login gmx \
+  --imap-host imap.gmx.com --imap-port 993 --imap-security tls \
+  --smtp-host mail.gmx.com --smtp-port 587 --smtp-security starttls \
+  --username you@gmx.com \
+  --password-command "security find-generic-password -w -s surface-gmx"
+
+surface auth status gmx
+```
+
+For GMX, enable POP3/IMAP in GMX web settings before logging in. Prefer a
+password manager, macOS Keychain, `--password-command`, `--password-env`, or
+`--password-file`; do not put mailbox passwords in the repo or `config.toml`.
+Surface reads MIME directly over IMAP, so it does not depend on webmail
+"show images" or "trust sender" UI. Remote images are not fetched; message body
+text, links, and MIME attachments can still be read and downloaded.
+
+Generic IMAP has no calendar action API. Calendar invites appear as ordinary
+message body plus `.ics`/calendar attachments, but `surface mail rsvp` remains
+unsupported for IMAP accounts. Archive also depends on the provider exposing an
+Archive or All Mail style mailbox.
 
 ## Headless Remote Setup
 
@@ -264,10 +294,10 @@ surface attachment download msg_01... att_01...
 
 surface mail send --account uni --to you@example.com --subject "hello" --body "test" --draft
 surface mail reply msg_01... --body "Thanks" --draft
-surface mail archive msg_01...
+surface mail archive msg_01...                 # when the provider exposes an archive mailbox
 surface mail mark-read msg_01...
 surface mail mark-unread msg_01...
-surface mail rsvp msg_01... --response tentative
+surface mail rsvp msg_01... --response tentative # Gmail/Outlook calendar invites only
 
 surface cache stats
 surface cache prune
@@ -291,8 +321,9 @@ Surface v1 supports:
 - bounded unread-state refresh with `sync-unread-state`
 - thread refresh and message read
 - attachment list/download
-- send/reply/reply-all/forward with `--draft`
-- archive, mark-read, mark-unread, RSVP
+- send/reply/reply-all/forward, with `--draft` as the safe path
+- archive where provider folders allow it, mark-read, and mark-unread
+- RSVP for Gmail/Outlook calendar invites
 - Outlook warm sessions for repeated read-path commands
 - optional summaries through OpenRouter or OpenClaw
 
@@ -300,6 +331,8 @@ Intentionally incomplete:
 
 - draft lifecycle commands
 - move/delete
+- generic IMAP RSVP/calendar mutations
+- public send-with-attachment upload flags
 - broad automated live coverage beyond the opt-in Gmail and Outlook v1 e2e
   scripts
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -31,7 +31,7 @@ Define the public Surface CLI commands and their machine-readable JSON output.
 Account identity notes:
 
 - `account add` defaults `--transport` from `--provider` in v1:
-  `gmail -> gmail-api`, `outlook -> outlook-web-playwright`
+  `gmail -> gmail-api`, `outlook -> outlook-web-playwright`, `imap -> imap-smtp`
 - `account add --email` seeds the account-owner identity with source `configured`
 - Gmail `auth login` and `auth status` upgrade the primary email to `provider_verified` when the
   authenticated Gmail profile exposes an address
@@ -87,6 +87,39 @@ Gmail auth notes:
   - `./client_secret.json` in the current working directory
 - Gmail auth stores refresh-token state under:
   - `~/.surface-cli/auth/<account_id>/gmail-token.json`
+
+IMAP/SMTP auth notes:
+
+- `surface account add <account> --provider imap --email <email>` defaults to
+  `transport = "imap-smtp"`.
+- `surface auth login <account>` for `imap-smtp` stores server settings and the mailbox/app
+  password under `~/.surface-cli/auth/<account_id>/imap-smtp.json`.
+- IMAP/SMTP accounts do not require a Google Cloud project or repo-root credentials JSON.
+- IMAP/SMTP login accepts provider settings through these flags:
+  - `--imap-host <host>`
+  - `--imap-port <port>`
+  - `--imap-security <tls|starttls|none>`
+  - `--smtp-host <host>`
+  - `--smtp-port <port>`
+  - `--smtp-security <tls|starttls|none>`
+  - `--username <username>`
+  - exactly one password source: `--password-env <name>`, `--password-file <path>`, or
+    `--password-command <command>`
+
+Example GMX-style IMAP/SMTP login:
+
+```bash
+surface account add gmx_test --provider imap --email you@gmx.net
+surface auth login gmx_test \
+  --imap-host imap.gmx.net \
+  --imap-port 993 \
+  --imap-security tls \
+  --smtp-host mail.gmx.net \
+  --smtp-port 587 \
+  --smtp-security starttls \
+  --username you@gmx.net \
+  --password-command "security find-generic-password -w -s surface-gmx-test"
+```
 
 Remote auth login returns the normal `auth-login` envelope plus:
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -109,17 +109,27 @@ IMAP/SMTP auth notes:
 Example GMX-style IMAP/SMTP login:
 
 ```bash
-surface account add gmx_test --provider imap --email you@gmx.net
+surface account add gmx_test --provider imap --email you@gmx.com
 surface auth login gmx_test \
-  --imap-host imap.gmx.net \
+  --imap-host imap.gmx.com \
   --imap-port 993 \
   --imap-security tls \
-  --smtp-host mail.gmx.net \
+  --smtp-host mail.gmx.com \
   --smtp-port 587 \
   --smtp-security starttls \
-  --username you@gmx.net \
+  --username you@gmx.com \
   --password-command "security find-generic-password -w -s surface-gmx-test"
 ```
+
+Generic IMAP/SMTP threading notes:
+
+- IMAP does not expose a provider conversation ID that reliably spans folders such as `INBOX` and
+  `Sent`.
+- Surface does not synthesize cross-folder conversations for generic IMAP in v1. A reply or
+  reply-all result returns the created Sent/Drafts `thread_ref` and `message_ref` when those refs can
+  be resolved, while `in_reply_to_message_ref` links back to the source message.
+- Gmail and Outlook may return the original provider conversation thread for replies because those
+  providers expose a native cross-folder conversation model.
 
 Remote auth login returns the normal `auth-login` envelope plus:
 

--- a/docs/decisions/0034-default-account-transport-from-provider.md
+++ b/docs/decisions/0034-default-account-transport-from-provider.md
@@ -12,6 +12,7 @@ each provider has exactly one implemented transport:
 
 - Gmail uses `gmail-api`
 - Outlook uses `outlook-web-playwright`
+- Generic IMAP accounts use `imap-smtp`
 
 Requiring users and agents to pass both `--provider` and `--transport` during account onboarding
 exposes implementation detail before it is useful.
@@ -23,6 +24,7 @@ Surface chooses the v1 default transport from the provider:
 
 - `--provider gmail` defaults to `gmail-api`
 - `--provider outlook` defaults to `outlook-web-playwright`
+- `--provider imap` defaults to `imap-smtp`
 
 Explicit `--transport` remains supported so future alternate adapters can be selected without
 changing the account storage model or public JSON shape.

--- a/docs/decisions/0040-generic-imap-uses-imap-smtp-transport.md
+++ b/docs/decisions/0040-generic-imap-uses-imap-smtp-transport.md
@@ -1,0 +1,35 @@
+# ADR 0040: Generic IMAP Uses IMAP/SMTP Transport
+
+## Status
+
+Accepted
+
+## Context
+
+Generic mailbox providers such as GMX expose reading and mailbox mutations through IMAP, but
+sending still happens through SMTP. Users think of this as one mail account, while Surface needs a
+transport name that is precise enough for auth, write behavior, and debugging.
+
+Surface also keeps account state in SQLite and auth material under `~/.surface-cli/auth/`; local
+policy remains in `config.toml`. Adding generic IMAP support should not change the normalized
+provider database schema.
+
+## Decision
+
+Surface adds `provider = "imap"` with default `transport = "imap-smtp"`.
+
+`surface auth login <account>` for this transport stores IMAP host/port/security, SMTP
+host/port/security, username, and mailbox/app password in the account auth directory. The password
+must come from a local source such as an environment variable, file, or password-command; it is not
+stored in the public repo, command docs, or `config.toml`.
+
+IMAP locators use the existing provider locator table. Thread and message identity is based on the
+mailbox plus IMAP UID/UIDVALIDITY, with RFC message IDs used as additional metadata when present.
+
+## Consequences
+
+- Generic IMAP accounts do not need a Google Cloud project or OAuth client JSON.
+- Existing Gmail and Outlook account behavior remains unchanged.
+- The existing SQLite schema remains sufficient because provider locators already store
+  transport-specific JSON.
+- RSVP remains unsupported for generic IMAP until calendar invite execution is explicitly designed.

--- a/docs/decisions/0040-generic-imap-uses-imap-smtp-transport.md
+++ b/docs/decisions/0040-generic-imap-uses-imap-smtp-transport.md
@@ -25,6 +25,9 @@ stored in the public repo, command docs, or `config.toml`.
 
 IMAP locators use the existing provider locator table. Thread and message identity is based on the
 mailbox plus IMAP UID/UIDVALIDITY, with RFC message IDs used as additional metadata when present.
+Generic IMAP does not synthesize cross-folder conversation threads in v1. Replies and reply-all
+messages are stored and returned using the resolved Sent/Drafts refs for the created message, and
+`in_reply_to_message_ref` links back to the source message.
 
 ## Consequences
 
@@ -32,4 +35,6 @@ mailbox plus IMAP UID/UIDVALIDITY, with RFC message IDs used as additional metad
 - Existing Gmail and Outlook account behavior remains unchanged.
 - The existing SQLite schema remains sufficient because provider locators already store
   transport-specific JSON.
+- Generic IMAP reply results can differ from Gmail/Outlook reply results when those providers expose
+  native cross-folder conversation IDs.
 - RSVP remains unsupported for generic IMAP until calendar invite execution is explicitly designed.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -61,3 +61,4 @@ Use zero-padded sequential numbers:
 - `0037-skill-install-command-installs-bundled-agent-skills.md`
 - `0038-bounded-unread-state-refresh.md`
 - `0039-sent-mail-is-message-first.md`
+- `0040-generic-imap-uses-imap-smtp-transport.md`

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -3,7 +3,7 @@
 ## Goal
 
 Define the normalized interface each provider transport must implement so Gmail,
-Outlook, and later providers can plug into the same CLI contract.
+Outlook, generic IMAP, and later providers can plug into the same CLI contract.
 
 ## Terminology
 
@@ -16,6 +16,7 @@ Examples:
 
 - `provider=gmail`, `transport=gmail-api`
 - `provider=outlook`, `transport=outlook-web-playwright`
+- `provider=imap`, `transport=imap-smtp`
 
 ## Requirements
 
@@ -38,42 +39,68 @@ Each provider implementation must support:
 - list attachments
 - download attachment
 
+New provider transports may land in staged milestones, but they must explicitly return
+machine-readable unsupported/not-implemented errors for unimplemented capabilities until they meet
+the full requirement set above.
+
 ## Required Adapter Interface
 
 Each provider transport should implement a shared adapter interface equivalent to:
 
 ```ts
 interface MailProviderAdapter {
-  readonly provider: "gmail" | "outlook";
+  readonly provider: "gmail" | "outlook" | "imap";
   readonly transport: string;
 
-  login(account: MailAccount): Promise<void>;
-  logout(account: MailAccount): Promise<void>;
-  authStatus(account: MailAccount): Promise<AuthStatus>;
+  login(account: MailAccount, context: ProviderContext): Promise<AuthStatus>;
+  logout(account: MailAccount, context: ProviderContext): Promise<AuthStatus>;
+  authStatus(account: MailAccount, context: ProviderContext): Promise<AuthStatus>;
 
-  search(account: MailAccount, query: SearchQuery): Promise<ThreadResult[]>;
-  fetchUnread(account: MailAccount, query: FetchUnreadQuery): Promise<ThreadResult[]>;
-  fetchSent(account: MailAccount, query: SentQuery): Promise<SentMessageResult[]>;
-  refreshThread(account: MailAccount, threadRef: string): Promise<void>;
-  readMessage(account: MailAccount, messageRef: string, refresh?: boolean): Promise<ReadResultEnvelope>;
-  sendMessage(account: MailAccount, input: SendMessageInput): Promise<SendResultEnvelope>;
-  reply(account: MailAccount, messageRef: string, input: ReplyInput): Promise<SendResultEnvelope>;
-  replyAll(account: MailAccount, messageRef: string, input: ReplyInput): Promise<SendResultEnvelope>;
-  forward(account: MailAccount, messageRef: string, input: ForwardInput): Promise<SendResultEnvelope>;
-  archive(account: MailAccount, messageRef: string): Promise<ArchiveResultEnvelope>;
-  markRead(account: MailAccount, messageRefs: string[]): Promise<MarkMessagesResultEnvelope>;
-  markUnread(account: MailAccount, messageRefs: string[]): Promise<MarkMessagesResultEnvelope>;
+  search(account: MailAccount, query: SearchQuery, context: ProviderContext): Promise<ThreadResult[]>;
+  fetchUnread(account: MailAccount, query: FetchUnreadQuery, context: ProviderContext): Promise<ThreadResult[]>;
+  fetchSent(account: MailAccount, query: SentQuery, context: ProviderContext): Promise<SentMessageResult[]>;
+  refreshThread(account: MailAccount, threadRef: string, context: ProviderContext): Promise<void>;
+  readMessage(
+    account: MailAccount,
+    messageRef: string,
+    refresh: boolean,
+    context: ProviderContext,
+  ): Promise<ReadResultEnvelope>;
+  sendMessage(account: MailAccount, input: SendMessageInput, context: ProviderContext): Promise<SendResultEnvelope>;
+  reply(
+    account: MailAccount,
+    messageRef: string,
+    input: ReplyInput,
+    context: ProviderContext,
+  ): Promise<SendResultEnvelope>;
+  replyAll(
+    account: MailAccount,
+    messageRef: string,
+    input: ReplyInput,
+    context: ProviderContext,
+  ): Promise<SendResultEnvelope>;
+  forward(
+    account: MailAccount,
+    messageRef: string,
+    input: ForwardInput,
+    context: ProviderContext,
+  ): Promise<SendResultEnvelope>;
+  archive(account: MailAccount, messageRef: string, context: ProviderContext): Promise<ArchiveResultEnvelope>;
+  markRead(account: MailAccount, messageRefs: string[], context: ProviderContext): Promise<MarkMessagesResultEnvelope>;
+  markUnread(account: MailAccount, messageRefs: string[], context: ProviderContext): Promise<MarkMessagesResultEnvelope>;
   rsvp(
     account: MailAccount,
     messageRef: string,
     response: "accept" | "decline" | "tentative",
+    context: ProviderContext,
   ): Promise<RsvpResultEnvelope>;
 
-  listAttachments(account: MailAccount, messageRef: string): Promise<AttachmentListEnvelope>;
+  listAttachments(account: MailAccount, messageRef: string, context: ProviderContext): Promise<AttachmentListEnvelope>;
   downloadAttachment(
     account: MailAccount,
     messageRef: string,
     attachmentId: string,
+    context: ProviderContext,
   ): Promise<AttachmentDownloadEnvelope>;
 }
 ```
@@ -91,6 +118,11 @@ conversation/message state through the same normalized cache used by search/fetc
 `SentQuery.thread_ref` is present, providers should refresh that specific thread when possible and
 return account-authored sent messages from the normalized stored thread, optionally also applying
 the recipient filter.
+
+`ProviderContext.authLoginOptions` carries provider-specific one-shot login settings collected by
+the CLI. In v1 this is used by `imap-smtp` for IMAP/SMTP host, port, security mode, username, and
+password source flags. Providers must store durable auth material under the account auth directory,
+not in the repo or local policy config.
 
 ## Normalization Rules
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",
+        "imapflow": "^1.3.5",
+        "mailparser": "^3.9.9",
         "playwright-core": "^1.55.0",
         "smol-toml": "^1.6.1",
         "ulid": "^3.0.2",
@@ -20,9 +22,13 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
+        "@types/mailparser": "^3.4.6",
         "@types/node": "^25.5.2",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -467,6 +473,28 @@
         "node": ">=18"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.12.0.tgz",
+      "integrity": "sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "~2.3.0",
+        "domhandler": "~5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      },
+      "peerDependencies": {
+        "selderee": "~0.12.0"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -477,6 +505,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mailparser": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@types/mailparser/-/mailparser-3.4.6.tgz",
+      "integrity": "sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "iconv-lite": "^0.6.3"
+      }
+    },
+    "node_modules/@types/mailparser/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
@@ -485,6 +537,26 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.12.tgz",
+      "integrity": "sha512-w7Gy+NvjZ0MiXm8F6zfjImAqcTONKDImgWVBjDKQVFUXWuz3VFM5levNArkL2M877ajql5+bkS2pDV56injlmg==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.8",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -604,6 +676,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -613,6 +694,70 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -620,6 +765,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -719,6 +876,81 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
+      "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "~0.12.0",
+        "deepmerge-ts": "^7.1.5",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^10.1.0",
+        "selderee": "~0.12.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -739,6 +971,23 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/imapflow": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.5.tgz",
+      "integrity": "sha512-1cWnj9V8eJuYizxfb4nzD2C+cE27pUOIg571d/U9pg046bJnz/d+rnp2HzXKqX9bYmkvxoQqw2w3TMGpmfiBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.12",
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libmime": "5.3.8",
+        "libqp": "2.1.1",
+        "nodemailer": "8.0.10",
+        "pino": "10.3.1",
+        "socks": "2.8.9"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -750,6 +999,85 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.7.0.tgz",
+      "integrity": "sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
+      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/mailparser": {
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.9.tgz",
+      "integrity": "sha512-ulZi7h1eKm8WQmXibIgj8dmMQGDQCUS/g+XHkxxjcLDq4Dwn2ppo+0hz5Fi+ltvu4eN7mh3ykIp5RcpiWWav1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.12",
+        "encoding-japanese": "2.2.0",
+        "he": "1.2.0",
+        "html-to-text": "10.0.0",
+        "iconv-lite": "0.7.2",
+        "libmime": "5.3.8",
+        "linkify-it": "5.0.1",
+        "nodemailer": "8.0.10",
+        "punycode.js": "2.3.1",
+        "tlds": "1.261.0"
+      }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -796,6 +1124,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -804,6 +1150,65 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/parseley": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.13.1.tgz",
+      "integrity": "sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.7.0",
+        "peberminta": "^0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.10.0.tgz",
+      "integrity": "sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/playwright-core": {
       "version": "1.59.1",
@@ -844,6 +1249,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -853,6 +1274,21 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -881,6 +1317,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -912,6 +1357,33 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/selderee": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz",
+      "integrity": "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "~0.13.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -970,6 +1442,16 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -980,6 +1462,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/string_decoder": {
@@ -1028,6 +1542,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -1073,6 +1614,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ulid": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "commander": "^14.0.3",
         "imapflow": "^1.3.5",
         "mailparser": "^3.9.9",
+        "nodemailer": "^8.0.10",
         "playwright-core": "^1.55.0",
         "smol-toml": "^1.6.1",
         "ulid": "^3.0.2",
@@ -24,6 +25,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/mailparser": "^3.4.6",
         "@types/node": "^25.5.2",
+        "@types/nodemailer": "^8.0.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
       },
@@ -537,6 +539,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@zone-eu/mailsplit": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "surface-cli",
   "version": "0.3.9",
-  "description": "A lean, local-first mail CLI for Gmail and Outlook with a JSON-first contract for automation.",
+  "description": "A lean, local-first mail CLI for Gmail, Outlook, and generic IMAP with a JSON-first contract for automation.",
   "homepage": "https://github.com/VishalJ99/surface-cli",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "surface": "dist/cli.js"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19.0"
   },
   "files": [
     "dist",
@@ -44,6 +44,8 @@
   "dependencies": {
     "better-sqlite3": "^12.8.0",
     "commander": "^14.0.3",
+    "imapflow": "^1.3.5",
+    "mailparser": "^3.9.9",
     "playwright-core": "^1.55.0",
     "smol-toml": "^1.6.1",
     "ulid": "^3.0.2",
@@ -51,6 +53,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/mailparser": "^3.4.6",
     "@types/node": "^25.5.2",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "commander": "^14.0.3",
     "imapflow": "^1.3.5",
     "mailparser": "^3.9.9",
+    "nodemailer": "^8.0.10",
     "playwright-core": "^1.55.0",
     "smol-toml": "^1.6.1",
     "ulid": "^3.0.2",
@@ -55,6 +56,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/mailparser": "^3.4.6",
     "@types/node": "^25.5.2",
+    "@types/nodemailer": "^8.0.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   }

--- a/skills/surface-cli/SKILL.md
+++ b/skills/surface-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: surface-cli
-description: "Use the Surface mail CLI to read and act on Gmail and Outlook mail through one JSON-first contract. Prefer this skill when you need Outlook access for school or work accounts that do not expose IMAP or require admin setup, plus stable refs for unread fetch, sent-message lookup, structured search, thread refresh, message read, attachments, send or draft, archive, mark read or unread, and Outlook RSVP."
+description: "Use the Surface mail CLI to read and act on Gmail, Outlook, and generic IMAP/SMTP mail through one JSON-first contract. Prefer this skill when you need Outlook access for school or work accounts that do not expose IMAP, or generic IMAP for providers such as GMX, plus stable refs for unread fetch, sent-message lookup, structured search, thread refresh, message read, attachments, send or draft, archive, mark read or unread, and provider-supported RSVP."
 metadata:
   {
     "openclaw":
@@ -24,14 +24,14 @@ metadata:
 
 # Surface CLI
 
-Surface is a local-first mail CLI for Gmail and Outlook. It is especially useful for Outlook
-school or work accounts that only work through the web UI and do not require IMAP or admin
-changes. Surface prints machine-readable JSON to stdout and stores local state in
-`~/.surface-cli`.
+Surface is a local-first mail CLI for Gmail, Outlook, and generic IMAP/SMTP. It is especially
+useful for Outlook school or work accounts that only work through the web UI, and for mail
+providers such as GMX that expose standard IMAP and SMTP settings. Surface prints
+machine-readable JSON to stdout and stores local state in `~/.surface-cli`.
 
 ## Use This Skill When
 
-- the user wants to read or triage email from Gmail or Outlook
+- the user wants to read or triage email from Gmail, Outlook, or an IMAP mailbox
 - the user needs a provider-neutral CLI for search, unread fetch, read, attachments, or actions
 - you need stable `thread_ref` / `message_ref` values for follow-up commands or thread watching
 
@@ -63,6 +63,7 @@ Add an account:
 ```bash
 surface account add personal_2 --provider gmail --email you@example.com
 surface account add uni --provider outlook --email you@example.com
+surface account add gmx --provider imap --email you@gmx.com
 ```
 
 For reliable `summary.needs_action`, Surface should know who the account owner is. Gmail auth can
@@ -78,6 +79,11 @@ Log in:
 ```bash
 surface auth login personal_2
 surface auth login uni
+surface auth login gmx \
+  --imap-host imap.gmx.com --imap-port 993 --imap-security tls \
+  --smtp-host mail.gmx.com --smtp-port 587 --smtp-security starttls \
+  --username you@gmx.com \
+  --password-command "security find-generic-password -w -s surface-gmx"
 ```
 
 Local policy lives in:
@@ -279,6 +285,12 @@ surface mail rsvp msg_01... --response accept
 
 - Gmail and Outlook both support read, search, unread fetch, attachments, send/reply/forward,
   archive, mark-read, mark-unread, RSVP, and `--draft`.
+- Generic IMAP/SMTP supports read, search, unread fetch, attachments, sent lookup,
+  send/reply/reply-all/forward, drafts, mark-read, and mark-unread. Archive works only when the
+  account exposes an Archive or All Mail style mailbox. RSVP is not supported for generic IMAP.
+- Generic IMAP does not expose a reliable cross-folder conversation ID. Replies return the created
+  Sent or Draft refs and include `in_reply_to_message_ref`; use `sent --recipient` or `sent
+  --thread` for sent-message lookup.
 - Gmail RSVP requires Google Calendar API access on the authenticated account. If RSVP returns a
   reauth error, re-run `surface auth login <account>`.
 
@@ -295,8 +307,10 @@ surface mail rsvp msg_01... --response accept
 ```bash
 surface account list
 surface auth status
+surface auth status gmx
 surface session start --account uni
 surface mail fetch-unread --account uni --limit 10
+surface mail search --account gmx --mailbox inbox --limit 5
 surface mail fetch-unread --account uni --session sess_01... --limit 10
 surface mail search --account personal_2 --from alerts@example.com --subject 'discount' --mailbox inbox --label unread --limit 5
 surface mail thread get thr_01... --refresh --session sess_01...

--- a/skills/surface-cli/SKILL.md
+++ b/skills/surface-cli/SKILL.md
@@ -86,6 +86,14 @@ surface auth login gmx \
   --password-command "security find-generic-password -w -s surface-gmx"
 ```
 
+For GMX and similar providers, make sure IMAP/POP3 access is enabled in the
+provider web settings before logging in. Generic IMAP login does not need a
+Google Cloud project, OAuth client JSON, Microsoft Graph app registration, or a
+browser session. It does need the provider's IMAP/SMTP settings and a mailbox or
+app password from a local secret source such as `--password-command`,
+`--password-env`, or `--password-file`. Do not ask the user to paste mailbox
+passwords into chat or store them in the repo.
+
 Local policy lives in:
 
 ```text
@@ -133,6 +141,7 @@ surface mail search --account uni --from registrar@school.edu --subject "waitlis
 surface mail search --account uni --session sess_01... --from registrar@school.edu --limit 10
 surface mail search --account personal_2 --mailbox inbox --label unread --text "sale" --limit 10
 surface mail search --account personal_2 --text "has:attachment newer_than:30d" --limit 5
+surface mail search --account gmx --mailbox inbox --limit 10
 ```
 
 ### List Sent Messages
@@ -233,10 +242,10 @@ surface mail forward msg_01... --to recipient@example.com --body "FYI"
 ### Mailbox Actions
 
 ```bash
-surface mail archive msg_01...
+surface mail archive msg_01...                  # IMAP requires an Archive/All Mail mailbox
 surface mail mark-read msg_01...
 surface mail mark-unread msg_01...
-surface mail rsvp msg_01... --response accept
+surface mail rsvp msg_01... --response accept   # Gmail/Outlook only; IMAP returns unsupported
 ```
 
 ## Workflow
@@ -273,6 +282,8 @@ surface mail rsvp msg_01... --response accept
 - `read` is cache-first by default. Use `--refresh` when you need live provider state.
 - the first session-backed Outlook query still pays mailbox setup cost; the main win is faster follow-on live reads in the same mailbox session
 - `read` does not download attachments. Use `surface attachment download`.
+- Generic IMAP reads raw MIME directly and does not need webmail "show images" or "trust sender"
+  UI. Remote images are not fetched; message body text, links, and MIME attachments still work.
 - `fetch-unread` and `search` do not mutate mailbox state.
 - passive watching should stay read-only; do not mark watched mail read unless the user explicitly asks
 - if the user asks for unread triage rather than passive watching, `mark-read` or `read --mark-read`
@@ -288,6 +299,8 @@ surface mail rsvp msg_01... --response accept
 - Generic IMAP/SMTP supports read, search, unread fetch, attachments, sent lookup,
   send/reply/reply-all/forward, drafts, mark-read, and mark-unread. Archive works only when the
   account exposes an Archive or All Mail style mailbox. RSVP is not supported for generic IMAP.
+- Public CLI send-with-attachment/upload flags are not supported yet. Receive-side attachment
+  list/download is supported.
 - Generic IMAP does not expose a reliable cross-folder conversation ID. Replies return the created
   Sent or Draft refs and include `in_reply_to_message_ref`; use `sent --recipient` or `sent
   --thread` for sent-message lookup.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
   startWarmSession,
   stopWarmSession,
 } from "./session.js";
+import type { ImapSmtpSecurityMode } from "./providers/types.js";
 
 interface GlobalOptions {
   config?: string;
@@ -40,9 +41,12 @@ interface GlobalOptions {
 const DEFAULT_SENT_LIMIT = 10;
 
 function positiveInt(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error("Expected a positive integer.");
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new SurfaceError("invalid_argument", "Expected a positive integer.");
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new SurfaceError("invalid_argument", "Expected a safe positive integer.");
   }
   return parsed;
 }
@@ -59,6 +63,17 @@ function normalizeOptionalString(value: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function normalizeOptionalImapSmtpSecurity(value: unknown): ImapSmtpSecurityMode | undefined {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "tls" || normalized === "starttls" || normalized === "none") {
+    return normalized;
+  }
+  throw new SurfaceError("invalid_argument", "Security mode must be one of: tls, starttls, none.");
+}
+
 function resolveAccountAddTransport(providerValue: unknown, transportValue: unknown): string {
   const explicitTransport = normalizeOptionalString(transportValue);
   if (explicitTransport) {
@@ -71,6 +86,8 @@ function resolveAccountAddTransport(providerValue: unknown, transportValue: unkn
       return "gmail-api";
     case "outlook":
       return "outlook-web-playwright";
+    case "imap":
+      return "imap-smtp";
   }
 }
 
@@ -246,7 +263,7 @@ const accountCommand = program.command("account").description("Manage Surface ac
 accountCommand
   .command("add")
   .argument("<name>", "Logical account name, for example work or personal")
-  .requiredOption("--provider <provider>", "Provider family, for example gmail or outlook")
+  .requiredOption("--provider <provider>", "Provider family, for example gmail, outlook, or imap")
   .option("--transport <transport>", "Transport name, defaults from provider")
   .requiredOption("--email <email>", "Primary mailbox email address")
   .action(async (name: string, options, command: Command) => {
@@ -362,6 +379,16 @@ authCommand
   .command("login")
   .argument("<account>", "Logical account name")
   .option("--remote-host <host>", "Run auth login against an existing Surface account on a remote host")
+  .option("--imap-host <host>", "IMAP server hostname for imap-smtp accounts")
+  .addOption(new Option("--imap-port <port>", "IMAP server port for imap-smtp accounts").argParser(positiveInt))
+  .option("--imap-security <mode>", "IMAP security mode: tls, starttls, or none")
+  .option("--smtp-host <host>", "SMTP server hostname for imap-smtp accounts")
+  .addOption(new Option("--smtp-port <port>", "SMTP server port for imap-smtp accounts").argParser(positiveInt))
+  .option("--smtp-security <mode>", "SMTP security mode: tls, starttls, or none")
+  .option("--username <username>", "Mailbox username for imap-smtp accounts")
+  .option("--password-env <name>", "Environment variable containing the mailbox or app password")
+  .option("--password-file <path>", "File containing the mailbox or app password")
+  .option("--password-command <command>", "Command that prints the mailbox or app password to stdout")
   .action(async (accountName: string, options, command: Command) => {
     if (options.remoteHost) {
       await runAction(command.optsWithGlobals<GlobalOptions>(), async (context) => {
@@ -372,7 +399,21 @@ authCommand
 
     await runAccountAction(command.optsWithGlobals<GlobalOptions>(), accountName, async (context) => {
       const adapter = resolveProviderAdapter(context.account);
-      const status = await adapter.login(context.account, context);
+      const status = await adapter.login(context.account, {
+        ...context,
+        authLoginOptions: {
+          imapHost: normalizeOptionalString(options.imapHost),
+          imapPort: options.imapPort,
+          imapSecurity: normalizeOptionalImapSmtpSecurity(options.imapSecurity),
+          smtpHost: normalizeOptionalString(options.smtpHost),
+          smtpPort: options.smtpPort,
+          smtpSecurity: normalizeOptionalImapSmtpSecurity(options.smtpSecurity),
+          username: normalizeOptionalString(options.username),
+          passwordEnv: normalizeOptionalString(options.passwordEnv),
+          passwordFile: normalizeOptionalString(options.passwordFile),
+          passwordCommand: normalizeOptionalString(options.passwordCommand),
+        },
+      });
       writeJson({
         schema_version: "1",
         command: "auth-login",

--- a/src/contracts/account.ts
+++ b/src/contracts/account.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const providerSchema = z.enum(["gmail", "outlook"]);
+export const providerSchema = z.enum(["gmail", "outlook", "imap"]);
 export type MailProvider = z.infer<typeof providerSchema>;
 
 export const accountInputSchema = z.object({

--- a/src/providers/imap/adapter.test.ts
+++ b/src/providers/imap/adapter.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type { ListResponse } from "imapflow";
 
+import type { MailAccount } from "../../contracts/account.js";
 import type { SentMessageResult } from "../../contracts/mail.js";
 import type { StoredMessageRecord } from "../../state/database.js";
 import { imapAdapterTestHooks } from "./adapter.js";
@@ -49,6 +50,18 @@ function sentMessage(input: {
       cached_bytes: 0,
     },
     attachments: [],
+  };
+}
+
+function account(): MailAccount {
+  return {
+    account_id: "acc_imap",
+    name: "imap",
+    provider: "imap",
+    transport: "imap-smtp",
+    email: "surface@example.com",
+    created_at: "2026-06-03T12:00:00.000Z",
+    updated_at: "2026-06-03T12:00:00.000Z",
   };
 }
 
@@ -115,6 +128,68 @@ test("filterSentMessagesForQuery keeps exact normalized To and Cc recipient matc
       .filterSentMessagesForQuery(messages, { recipient: "recipient@example.com", limit: 10 })
       .map((message) => message.message_ref),
     ["msg_to", "msg_cc"],
+  );
+});
+
+test("buildComposeRaw hides Bcc from delivery MIME while preserving it for stored copies", () => {
+  const raw = imapAdapterTestHooks.buildComposeRaw({
+    account: account(),
+    recipients: {
+      to: ["to@example.com"],
+      cc: ["cc@example.com"],
+      bcc: ["hidden@example.com"],
+    },
+    subject: "Surface probe",
+    body: "Hello",
+    messageId: "<surface-test@example.com>",
+  });
+
+  assert.match(raw.deliveryRaw, /^To: to@example\.com/m);
+  assert.match(raw.deliveryRaw, /^Cc: cc@example\.com/m);
+  assert.match(raw.deliveryRaw, /^Date: /m);
+  assert.doesNotMatch(raw.deliveryRaw, /^Bcc:/m);
+  assert.match(raw.storedRaw, /^Date: /m);
+  assert.match(raw.storedRaw, /^Bcc: hidden@example\.com/m);
+});
+
+test("buildComposeRaw neutralizes bare CR and LF header injection", () => {
+  const raw = imapAdapterTestHooks.buildComposeRaw({
+    account: account(),
+    recipients: {
+      to: ["to@example.com\rBcc: injected@example.com"],
+      cc: [],
+      bcc: [],
+    },
+    subject: "Surface\rBcc: injected@example.com\nCc: injected@example.com",
+    body: "Hello",
+    messageId: "<surface-test@example.com>",
+  });
+
+  assert.match(raw.deliveryRaw, /^To: to@example\.com Bcc: injected@example\.com/m);
+  assert.match(raw.deliveryRaw, /^Subject: Surface Bcc: injected@example\.com Cc: injected@example\.com/m);
+  assert.doesNotMatch(raw.deliveryRaw, /^Bcc: injected@example\.com/m);
+  assert.doesNotMatch(raw.deliveryRaw, /^Cc: injected@example\.com/m);
+});
+
+test("IMAP drafts append as seen drafts and sent appends as seen", () => {
+  assert.deepEqual(imapAdapterTestHooks.draftAppendFlags, ["\\Draft", "\\Seen"]);
+  assert.deepEqual(imapAdapterTestHooks.sentAppendFlags, ["\\Seen"]);
+});
+
+test("replyReferences appends the original Message-ID to existing references", () => {
+  assert.equal(
+    imapAdapterTestHooks.replyReferences({
+      messageId: "<latest@example.com>",
+      references: "<root@example.com>",
+    }),
+    "<root@example.com> <latest@example.com>",
+  );
+  assert.equal(
+    imapAdapterTestHooks.replyReferences({
+      messageId: "<latest@example.com>",
+      references: null,
+    }),
+    "<latest@example.com>",
   );
 });
 

--- a/src/providers/imap/adapter.test.ts
+++ b/src/providers/imap/adapter.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ListResponse } from "imapflow";
+
+import type { SentMessageResult } from "../../contracts/mail.js";
+import type { StoredMessageRecord } from "../../state/database.js";
+import { imapAdapterTestHooks } from "./adapter.js";
+
+function mailbox(input: Partial<ListResponse> & Pick<ListResponse, "path">): ListResponse {
+  return {
+    path: input.path,
+    name: input.name ?? input.path,
+    listed: true,
+    subscribed: false,
+    delimiter: "/",
+    flags: new Set(),
+    specialUse: input.specialUse,
+  } as ListResponse;
+}
+
+function sentMessage(input: {
+  messageRef: string;
+  to?: string[];
+  cc?: string[];
+}): SentMessageResult {
+  const participants = (input.to ?? []).map((email) => ({ name: email, email }));
+  const cc = (input.cc ?? []).map((email) => ({ name: email, email }));
+  return {
+    message_ref: input.messageRef,
+    thread_ref: `thr_${input.messageRef}`,
+    source: {
+      provider: "imap",
+      transport: "imap-smtp",
+    },
+    envelope: {
+      from: { name: "Surface Tester", email: "tester@example.com" },
+      to: participants,
+      cc,
+      sent_at: "2026-06-03T12:00:00.000Z",
+      received_at: "2026-06-03T12:00:00.000Z",
+      unread: false,
+    },
+    snippet: "",
+    body: {
+      text: "",
+      truncated: false,
+      cached: true,
+      cached_bytes: 0,
+    },
+    attachments: [],
+  };
+}
+
+function storedMessage(input: {
+  subject?: string;
+  from?: string;
+  sentAt?: string;
+  receivedAt?: string;
+  snippet?: string;
+}): StoredMessageRecord {
+  return {
+    message_ref: "msg_existing",
+    account_id: "acc_existing",
+    thread_ref: "thr_existing",
+    subject: input.subject ?? "Archive me",
+    from_name: "Sender",
+    from_email: input.from ?? "sender@example.com",
+    to_json: "[]",
+    cc_json: "[]",
+    sent_at: input.sentAt ?? "2026-06-03T12:00:00.000Z",
+    received_at: input.receivedAt ?? "2026-06-03T12:00:01.000Z",
+    unread: 0,
+    snippet: input.snippet ?? "Archive me body",
+    body_cache_path: null,
+    body_cached: 0,
+    body_truncated: 0,
+    body_cached_bytes: 0,
+    invite_json: null,
+  };
+}
+
+test("resolveMailboxPath treats IMAP \\All special-use as archive", () => {
+  assert.equal(
+    imapAdapterTestHooks.resolveMailboxPath([
+      mailbox({ path: "INBOX", specialUse: "\\Inbox" }),
+      mailbox({ path: "[Provider]/Everything", specialUse: "\\All" }),
+    ], "archive"),
+    "[Provider]/Everything",
+  );
+});
+
+test("buildSentSearch narrows recipient searches through To or Cc and overfetches for post-filtering", () => {
+  const { search, fetchLimit } = imapAdapterTestHooks.buildSentSearch({
+    recipient: "recipient@example.com",
+    limit: 10,
+  });
+
+  assert.equal(fetchLimit, 50);
+  assert.deepEqual(search.or, [
+    { to: "recipient@example.com" },
+    { cc: "recipient@example.com" },
+  ]);
+});
+
+test("filterSentMessagesForQuery keeps exact normalized To and Cc recipient matches only", () => {
+  const messages = [
+    sentMessage({ messageRef: "msg_to", to: ["Recipient@Example.com"] }),
+    sentMessage({ messageRef: "msg_cc", cc: ["recipient@example.com"] }),
+    sentMessage({ messageRef: "msg_substring", to: ["not-recipient@example.com"] }),
+  ];
+
+  assert.deepEqual(
+    imapAdapterTestHooks
+      .filterSentMessagesForQuery(messages, { recipient: "recipient@example.com", limit: 10 })
+      .map((message) => message.message_ref),
+    ["msg_to", "msg_cc"],
+  );
+});
+
+test("archivedThreadMatchesStoredMessage matches moved messages by Message-ID", () => {
+  const stored = storedMessage({});
+  const thread = sentMessage({ messageRef: "msg_moved" });
+
+  assert.equal(
+    imapAdapterTestHooks.archivedThreadMatchesStoredMessage(
+      stored,
+      {
+        mailbox: "INBOX",
+        uid_validity: "1",
+        uid: 10,
+        message_id: "<message@example.com>",
+        in_reply_to: null,
+        references: null,
+      },
+      {
+        ...thread,
+        envelope: {
+          subject: "Archive me",
+          participants: [],
+          mailbox: "archive",
+          labels: ["archive"],
+          received_at: "2026-06-03T12:00:01.000Z",
+          message_count: 1,
+          unread_count: 0,
+          has_attachments: false,
+        },
+        summary: null,
+        messages: [{
+          ...thread,
+          locator: {
+            kind: "message",
+            locator: {
+              mailbox: "Archive",
+              uid_validity: "2",
+              uid: 20,
+              message_id: "<message@example.com>",
+              in_reply_to: null,
+              references: null,
+            },
+          },
+        }],
+      },
+    ),
+    true,
+  );
+});
+
+test("archivedThreadMatchesStoredMessage can recover no-Message-ID moves with normalized envelope facts", () => {
+  const stored = storedMessage({});
+  const message = sentMessage({ messageRef: "msg_moved" });
+
+  assert.equal(
+    imapAdapterTestHooks.archivedThreadMatchesStoredMessage(
+      stored,
+      {
+        mailbox: "INBOX",
+        uid_validity: "1",
+        uid: 10,
+        message_id: null,
+        in_reply_to: null,
+        references: null,
+      },
+      {
+        thread_ref: "thr_moved",
+        source: message.source,
+        envelope: {
+          subject: "Archive me",
+          participants: [],
+          mailbox: "archive",
+          labels: ["archive"],
+          received_at: "2026-06-03T12:00:01.000Z",
+          message_count: 1,
+          unread_count: 0,
+          has_attachments: false,
+        },
+        summary: null,
+        messages: [{
+          ...message,
+          envelope: {
+            ...message.envelope,
+            subject: "Archive me",
+            from: { name: "Sender", email: "sender@example.com" },
+            sent_at: "2026-06-03T12:00:00.000Z",
+            received_at: "2026-06-03T12:00:01.000Z",
+          },
+          snippet: "Archive me body",
+          locator: {
+            kind: "message",
+            locator: {
+              mailbox: "Archive",
+              uid_validity: "2",
+              uid: 20,
+              message_id: null,
+              in_reply_to: null,
+              references: null,
+            },
+          },
+        }],
+      },
+    ),
+    true,
+  );
+});

--- a/src/providers/imap/adapter.test.ts
+++ b/src/providers/imap/adapter.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import type { ListResponse } from "imapflow";
 
 import type { MailAccount } from "../../contracts/account.js";
-import type { SentMessageResult } from "../../contracts/mail.js";
+import type { NormalizedAttachmentRecord, SentMessageResult } from "../../contracts/mail.js";
 import type { StoredMessageRecord } from "../../state/database.js";
 import { imapAdapterTestHooks } from "./adapter.js";
 
@@ -174,6 +174,40 @@ test("buildComposeRaw neutralizes bare CR and LF header injection", () => {
 test("IMAP drafts append as seen drafts and sent appends as seen", () => {
   assert.deepEqual(imapAdapterTestHooks.draftAppendFlags, ["\\Draft", "\\Seen"]);
   assert.deepEqual(imapAdapterTestHooks.sentAppendFlags, ["\\Seen"]);
+});
+
+test("IMAP attachment provider keys remain unique for duplicate checksum parts", () => {
+  const messageLocator = {
+    mailbox: "INBOX",
+    uid_validity: "1",
+    uid: 42,
+    message_id: "<invite@example.com>",
+    in_reply_to: null,
+    references: null,
+  };
+  const attachment = (index: number): NormalizedAttachmentRecord => ({
+    attachment_id: "",
+    filename: "invite.ics",
+    mime_type: "text/calendar",
+    size_bytes: 123,
+    inline: false,
+    locator: {
+      kind: "attachment",
+      locator: {
+        mailbox: "INBOX",
+        uid_validity: "1",
+        uid: 42,
+        index,
+        checksum: "same-calendar-checksum",
+        filename: "invite.ics",
+      },
+    },
+  });
+
+  assert.notEqual(
+    imapAdapterTestHooks.imapAttachmentProviderKey(messageLocator, attachment(0), 0),
+    imapAdapterTestHooks.imapAttachmentProviderKey(messageLocator, attachment(1), 1),
+  );
 });
 
 test("reply recipients treat Reply-To as authoritative over From", () => {

--- a/src/providers/imap/adapter.test.ts
+++ b/src/providers/imap/adapter.test.ts
@@ -176,6 +176,37 @@ test("IMAP drafts append as seen drafts and sent appends as seen", () => {
   assert.deepEqual(imapAdapterTestHooks.sentAppendFlags, ["\\Seen"]);
 });
 
+test("reply recipients treat Reply-To as authoritative over From", () => {
+  const recipients = imapAdapterTestHooks.buildReplyRecipients({
+    replyTo: ["support@example.com"],
+    from: ["sender@example.com"],
+    originalTo: ["surface@example.com"],
+    inputCc: [],
+    inputBcc: [],
+    selfEmails: new Set(["surface@example.com"]),
+  });
+
+  assert.deepEqual(recipients.to, ["support@example.com"]);
+  assert.deepEqual(recipients.cc, []);
+  assert.deepEqual(recipients.bcc, []);
+});
+
+test("reply-all recipients do not add From when Reply-To is present", () => {
+  const recipients = imapAdapterTestHooks.buildReplyAllRecipients({
+    replyTo: ["support@example.com"],
+    from: ["sender@example.com"],
+    originalTo: ["surface@example.com", "other@example.com"],
+    originalCc: ["cc@example.com"],
+    inputCc: ["manual@example.com"],
+    inputBcc: [],
+    selfEmails: new Set(["surface@example.com"]),
+  });
+
+  assert.deepEqual(recipients.to, ["support@example.com"]);
+  assert.deepEqual(recipients.cc, ["other@example.com", "cc@example.com", "manual@example.com"]);
+  assert.deepEqual(recipients.bcc, []);
+});
+
 test("replyReferences appends the original Message-ID to existing references", () => {
   assert.equal(
     imapAdapterTestHooks.replyReferences({

--- a/src/providers/imap/adapter.ts
+++ b/src/providers/imap/adapter.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -16,12 +17,14 @@ import {
   type EmailAddress,
   type ParsedMail,
 } from "mailparser";
+import { createTransport, type SendMailOptions } from "nodemailer";
 
 import type { MailAccount } from "../../contracts/account.js";
 import type {
   ArchiveResultEnvelope,
   AttachmentDownloadEnvelope,
   AttachmentListEnvelope,
+  ComposeRecipients,
   FetchUnreadQuery,
   ForwardInput,
   MarkMessagesResultEnvelope,
@@ -42,9 +45,14 @@ import type {
   SentQuery,
   ThreadParticipant,
 } from "../../contracts/mail.js";
-import { SurfaceError, notImplemented } from "../../lib/errors.js";
+import { SurfaceError } from "../../lib/errors.js";
 import { toPublicSentMessage } from "../../lib/public-mail.js";
-import { messageMatchesRecipient, normalizeComparableEmail, sentMessagesFromStoredThread } from "../../lib/sent-mail.js";
+import {
+  accountIdentityEmails,
+  messageMatchesRecipient,
+  normalizeComparableEmail,
+  sentMessagesFromStoredThread,
+} from "../../lib/sent-mail.js";
 import { assertWriteAllowed } from "../../lib/write-safety.js";
 import { makeAttachmentId, makeMessageRef, makeThreadRef } from "../../refs.js";
 import { summarizeAndPersistThreads } from "../../summarizer.js";
@@ -137,6 +145,36 @@ async function withImapClient<T>(
     } catch {
       client.close();
     }
+  }
+}
+
+async function withSmtpTransport<T>(
+  account: MailAccount,
+  context: ProviderContext,
+  work: (transport: ReturnType<typeof createTransport>) => Promise<T>,
+): Promise<T> {
+  const state = readImapSmtpAuthState(account, context);
+  const transport = createTransport({
+    host: state.smtp.host,
+    port: state.smtp.port,
+    secure: state.smtp.security === "tls",
+    requireTLS: state.smtp.security === "starttls",
+    ignoreTLS: state.smtp.security === "none",
+    auth: {
+      user: state.username,
+      pass: state.password,
+    },
+    connectionTimeout: context.config.providerTimeoutMs,
+    greetingTimeout: context.config.providerTimeoutMs,
+    socketTimeout: context.config.providerTimeoutMs,
+    disableFileAccess: true,
+    disableUrlAccess: true,
+  });
+
+  try {
+    return await work(transport);
+  } finally {
+    transport.close();
   }
 }
 
@@ -608,6 +646,149 @@ function buildMarkMessagesEnvelope(
     account: account.name,
     source: sourceInfo(account),
     updated,
+  };
+}
+
+function participantFromEmail(email: string): MessageParticipant {
+  return {
+    name: email,
+    email,
+  };
+}
+
+function recipientsFromInput(input: { to: string[]; cc: string[]; bcc: string[] }): ComposeRecipients {
+  return {
+    to: input.to.map(participantFromEmail),
+    cc: input.cc.map(participantFromEmail),
+    bcc: input.bcc.map(participantFromEmail),
+  };
+}
+
+function normalizeEmailList(values: Array<string | null | undefined>): string[] {
+  const deduped = new Set<string>();
+  for (const value of values) {
+    const normalized = value?.trim();
+    if (!normalized) {
+      continue;
+    }
+    deduped.add(normalized);
+  }
+  return [...deduped];
+}
+
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function prefixSubject(subject: string, prefix: "Re" | "Fwd"): string {
+  const normalized = subject.trim();
+  if (!normalized) {
+    return `${prefix}:`;
+  }
+  const matcher = prefix === "Re" ? /^re:\s/i : /^(fwd|fw):\s/i;
+  return matcher.test(normalized) ? normalized : `${prefix}: ${normalized}`;
+}
+
+function quoteLines(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+function buildReplyBody(inputBody: string, stored: StoredMessageRecord): string {
+  const parsed = parseStoredMessage(stored);
+  const originalBody = parsed.body.text.trim();
+  const originalFrom = parsed.envelope.from?.email ?? parsed.envelope.from?.name ?? "unknown sender";
+  const originalDate = parsed.envelope.sent_at ?? parsed.envelope.received_at ?? "unknown time";
+  if (!originalBody) {
+    return inputBody;
+  }
+  return `${inputBody}\n\nOn ${originalDate}, ${originalFrom} wrote:\n${quoteLines(originalBody)}`;
+}
+
+function buildForwardBody(inputBody: string, stored: StoredMessageRecord): string {
+  const parsed = parseStoredMessage(stored);
+  const originalBody = parsed.body.text.trim();
+  const lines = [
+    inputBody,
+    "",
+    "---------- Forwarded message ---------",
+    `From: ${parsed.envelope.from?.email ?? parsed.envelope.from?.name ?? ""}`,
+    `Date: ${parsed.envelope.sent_at ?? parsed.envelope.received_at ?? ""}`,
+    `Subject: ${parsed.envelope.subject ?? ""}`,
+    `To: ${parsed.envelope.to.map((mailbox) => mailbox.email).join(", ")}`,
+  ];
+  if (parsed.envelope.cc.length > 0) {
+    lines.push(`Cc: ${parsed.envelope.cc.map((mailbox) => mailbox.email).join(", ")}`);
+  }
+  lines.push("", originalBody);
+  return lines.join("\n").trim();
+}
+
+function makeSmtpMessageId(account: MailAccount): string {
+  const domain = account.email.split("@")[1]?.trim() || "surface.local";
+  return `<surface-${Date.now()}-${randomUUID()}@${domain}>`;
+}
+
+function rfc2822Date(value: Date = new Date()): string {
+  return value.toUTCString().replace("GMT", "+0000");
+}
+
+function buildRawMimeMessage(input: {
+  from: string;
+  to: string[];
+  cc: string[];
+  bcc: string[];
+  subject: string;
+  body: string;
+  messageId: string;
+  date?: string;
+  inReplyTo?: string | null | undefined;
+  includeBccHeader?: boolean;
+  references?: string | null | undefined;
+}): string {
+  const lines = [
+    `From: ${sanitizeHeaderValue(input.from)}`,
+    ...(input.to.length > 0 ? [`To: ${input.to.map(sanitizeHeaderValue).join(", ")}`] : []),
+    ...(input.cc.length > 0 ? [`Cc: ${input.cc.map(sanitizeHeaderValue).join(", ")}`] : []),
+    ...(input.includeBccHeader && input.bcc.length > 0 ? [`Bcc: ${input.bcc.map(sanitizeHeaderValue).join(", ")}`] : []),
+    `Subject: ${sanitizeHeaderValue(input.subject)}`,
+    `Message-ID: ${sanitizeHeaderValue(input.messageId)}`,
+    `Date: ${sanitizeHeaderValue(input.date ?? rfc2822Date())}`,
+    ...(input.inReplyTo ? [`In-Reply-To: ${sanitizeHeaderValue(input.inReplyTo)}`] : []),
+    ...(input.references ? [`References: ${sanitizeHeaderValue(input.references)}`] : []),
+    "MIME-Version: 1.0",
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    input.body.replace(/\r\n/g, "\n"),
+    "",
+  ];
+  return lines.join("\r\n");
+}
+
+function buildSendEnvelope(
+  account: MailAccount,
+  command: SendResultEnvelope["command"],
+  status: SendResultEnvelope["status"],
+  subject: string,
+  recipients: ComposeRecipients,
+  result: { thread_ref: string | null; message_ref: string | null },
+  inReplyToMessageRef: string | null,
+): SendResultEnvelope {
+  return {
+    schema_version: "1",
+    command,
+    account: account.name,
+    source: sourceInfo(account),
+    status,
+    subject,
+    recipients,
+    thread_ref: result.thread_ref,
+    message_ref: result.message_ref,
+    in_reply_to_message_ref: inReplyToMessageRef,
   };
 }
 
@@ -1122,6 +1303,255 @@ async function fetchSentMessages(
   });
 }
 
+function mailboxExists(mailboxes: ListResponse[], path: string): boolean {
+  return mailboxes.some((mailbox) => mailbox.path === path);
+}
+
+async function findAppendedThreadByMessageId(
+  account: MailAccount,
+  client: ImapFlow,
+  mailboxPath: string,
+  messageId: string,
+): Promise<NormalizedThreadRecord | null> {
+  await client.mailboxOpen(mailboxPath);
+  const matches = await client.search({ header: { "message-id": messageId } }, { uid: true });
+  const uids = Array.isArray(matches) ? matches.slice(-1).reverse() : [];
+  const [thread] = await fetchUidThreads(account, client, mailboxPath, uids);
+  return thread ?? null;
+}
+
+function persistMailboxThreadRefs(
+  account: MailAccount,
+  context: ProviderContext,
+  thread: NormalizedThreadRecord | null,
+): { thread_ref: string | null; message_ref: string | null } | null {
+  if (!thread) {
+    return null;
+  }
+  const [persisted] = persistThreads(account, context, [thread]);
+  return persisted
+    ? {
+      thread_ref: persisted.thread_ref,
+      message_ref: persisted.messages[0]?.message_ref ?? null,
+    }
+    : null;
+}
+
+async function appendMimeToMailbox(
+  account: MailAccount,
+  context: ProviderContext,
+  mailboxAlias: "sent" | "drafts",
+  rawMime: string,
+  messageId: string,
+  flags: string[],
+): Promise<{ thread_ref: string | null; message_ref: string | null } | null> {
+  return withImapClient(account, context, async (client) => {
+    const mailboxes = await client.list();
+    const mailboxPath = resolveMailboxPath(mailboxes, mailboxAlias);
+    if (!mailboxExists(mailboxes, mailboxPath)) {
+      throw new SurfaceError("unsupported", `This IMAP account does not expose a ${mailboxAlias} mailbox.`, {
+        account: account.name,
+      });
+    }
+
+    const appended = await client.append(mailboxPath, Buffer.from(rawMime, "utf8"), flags);
+    let thread: NormalizedThreadRecord | null = null;
+    if (appended && typeof appended.uid === "number") {
+      const [fetched] = await fetchUidThreads(account, client, mailboxPath, [appended.uid]);
+      thread = fetched ?? null;
+    }
+    thread ??= await findAppendedThreadByMessageId(account, client, mailboxPath, messageId);
+
+    return persistMailboxThreadRefs(account, context, thread);
+  });
+}
+
+async function findMailboxMessageRefsByMessageId(
+  account: MailAccount,
+  context: ProviderContext,
+  mailboxAlias: "sent" | "drafts",
+  messageId: string,
+  options: {
+    attempts?: number;
+    delayMs?: number;
+  } = {},
+): Promise<{ thread_ref: string | null; message_ref: string | null } | null> {
+  const attempts = Math.max(1, options.attempts ?? 1);
+  const delayMs = Math.max(0, options.delayMs ?? 0);
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const refs = await withImapClient(account, context, async (client) => {
+      const mailboxes = await client.list();
+      const mailboxPath = resolveMailboxPath(mailboxes, mailboxAlias);
+      if (!mailboxExists(mailboxes, mailboxPath)) {
+        return null;
+      }
+      return persistMailboxThreadRefs(
+        account,
+        context,
+        await findAppendedThreadByMessageId(account, client, mailboxPath, messageId),
+      );
+    });
+    if (refs || attempt === attempts - 1) {
+      return refs;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  return null;
+}
+
+const DRAFT_APPEND_FLAGS = ["\\Draft", "\\Seen"];
+const SENT_APPEND_FLAGS = ["\\Seen"];
+
+function buildComposeRaw(input: {
+  account: MailAccount;
+  recipients: { to: string[]; cc: string[]; bcc: string[] };
+  subject: string;
+  body: string;
+  messageId: string;
+  inReplyTo?: string | null | undefined;
+  references?: string | null | undefined;
+}): { deliveryRaw: string; storedRaw: string } {
+  const base = {
+    from: input.account.email,
+    to: input.recipients.to,
+    cc: input.recipients.cc,
+    bcc: input.recipients.bcc,
+    subject: input.subject,
+    body: input.body,
+    messageId: input.messageId,
+    inReplyTo: input.inReplyTo,
+    references: input.references,
+  };
+  return {
+    deliveryRaw: buildRawMimeMessage({ ...base, includeBccHeader: false }),
+    storedRaw: buildRawMimeMessage({ ...base, includeBccHeader: true }),
+  };
+}
+
+async function sendRawSmtpMessage(
+  account: MailAccount,
+  context: ProviderContext,
+  rawMime: string,
+  recipients: { to: string[]; cc: string[]; bcc: string[] },
+): Promise<void> {
+  const envelopeRecipients = [...recipients.to, ...recipients.cc, ...recipients.bcc];
+  const message: SendMailOptions = {
+    raw: rawMime,
+    envelope: {
+      from: account.email,
+      to: envelopeRecipients,
+    },
+  };
+  await withSmtpTransport(account, context, async (transport) => {
+    await transport.sendMail(message);
+  });
+}
+
+async function sendOrDraftImapSmtpMessage(input: {
+  account: MailAccount;
+  context: ProviderContext;
+  recipients: { to: string[]; cc: string[]; bcc: string[] };
+  subject: string;
+  body: string;
+  draft: boolean;
+  inReplyTo?: string | null | undefined;
+  references?: string | null | undefined;
+}): Promise<{ status: SendResultEnvelope["status"]; refs: { thread_ref: string | null; message_ref: string | null } }> {
+  const messageId = makeSmtpMessageId(input.account);
+  const raw = buildComposeRaw({
+    account: input.account,
+    recipients: input.recipients,
+    subject: input.subject,
+    body: input.body,
+    messageId,
+    inReplyTo: input.inReplyTo,
+    references: input.references,
+  });
+
+  if (input.draft) {
+    const refs = await appendMimeToMailbox(
+      input.account,
+      input.context,
+      "drafts",
+      raw.storedRaw,
+      messageId,
+      DRAFT_APPEND_FLAGS,
+    );
+    if (!refs) {
+      throw new SurfaceError("transport_error", "IMAP draft append succeeded but the appended draft could not be resolved.", {
+        account: input.account.name,
+      });
+    }
+    return { status: "drafted", refs };
+  }
+
+  await sendRawSmtpMessage(input.account, input.context, raw.deliveryRaw, input.recipients);
+  const providerFiledRefs = await findMailboxMessageRefsByMessageId(
+    input.account,
+    input.context,
+    "sent",
+    messageId,
+    {
+      attempts: 3,
+      delayMs: 1_000,
+    },
+  ).catch(() => null);
+  const refs = providerFiledRefs ?? await appendMimeToMailbox(
+    input.account,
+    input.context,
+    "sent",
+    raw.storedRaw,
+    messageId,
+    SENT_APPEND_FLAGS,
+  ).catch(() => null);
+  return { status: "sent", refs: refs ?? { thread_ref: null, message_ref: null } };
+}
+
+async function resolveComposeTarget(
+  account: MailAccount,
+  context: ProviderContext,
+  messageRef: string,
+): Promise<{
+  stored: StoredMessageRecord;
+  parsed: ParsedMail;
+  messageId: string | null;
+  references: string | null;
+}> {
+  const stored = requireMessageForAccount(account, messageRef, context);
+  const locatorRow = context.db.findProviderLocator("message", messageRef);
+  if (!locatorRow) {
+    throw new SurfaceError("cache_miss", `No provider locator exists for message '${messageRef}'.`, {
+      account: account.name,
+      messageRef,
+      threadRef: stored.thread_ref,
+    });
+  }
+  const locator = parseMessageLocator(locatorRow.locator_json);
+  const parsed = await simpleParser(await readMessageSource(account, context, locator));
+  return {
+    stored,
+    parsed,
+    messageId: parsed.messageId ?? locator.message_id,
+    references: referencesToString(parsed.references) ?? locator.references,
+  };
+}
+
+function emailsFromAddressObject(value: AddressObject | AddressObject[] | undefined): string[] {
+  return addressesFromObject(value)
+    .map((address) => address.email)
+    .filter(Boolean);
+}
+
+function withoutAccountEmails(emails: string[], selfEmails: Set<string>): string[] {
+  return emails.filter((email) => !selfEmails.has(normalizeComparableEmail(email)));
+}
+
+function replyReferences(target: { messageId: string | null; references: string | null }): string | null {
+  return target.references
+    ? `${target.references}${target.messageId ? ` ${target.messageId}` : ""}`.trim()
+    : target.messageId;
+}
+
 function sanitizeAttachmentFilename(filename: string): string {
   const sanitized = filename.replace(/[\\/:*?"<>|\u0000-\u001F]/gu, "_").trim();
   return sanitized || "attachment";
@@ -1212,9 +1642,13 @@ async function mutateSeenFlag(
 
 export const imapAdapterTestHooks = {
   archivedThreadMatchesStoredMessage,
+  buildComposeRaw,
   buildSentSearch,
+  draftAppendFlags: DRAFT_APPEND_FLAGS,
   filterSentMessagesForQuery,
+  replyReferences,
   resolveMailboxPath,
+  sentAppendFlags: SENT_APPEND_FLAGS,
 };
 
 export class ImapSmtpAdapter implements MailProviderAdapter {
@@ -1413,37 +1847,214 @@ export class ImapSmtpAdapter implements MailProviderAdapter {
 
   async sendMessage(
     account: MailAccount,
-    _input: SendMessageInput,
-    _context: ProviderContext,
+    input: SendMessageInput,
+    context: ProviderContext,
   ): Promise<SendResultEnvelope> {
-    notImplemented("IMAP/SMTP send is not implemented yet.", account.name);
+    const recipients = {
+      to: normalizeEmailList(input.to),
+      cc: normalizeEmailList(input.cc),
+      bcc: normalizeEmailList(input.bcc),
+    };
+    const subject = input.subject.trim();
+    if (recipients.to.length === 0) {
+      throw new SurfaceError("invalid_argument", "IMAP/SMTP send requires at least one --to recipient.", {
+        account: account.name,
+      });
+    }
+    if (!subject) {
+      throw new SurfaceError("invalid_argument", "IMAP/SMTP send requires a non-empty --subject.", {
+        account: account.name,
+      });
+    }
+
+    assertWriteAllowed(context.config, account, recipients, {
+      disposition: input.draft ? "draft" : "send",
+    });
+
+    const result = await sendOrDraftImapSmtpMessage({
+      account,
+      context,
+      recipients,
+      subject,
+      body: input.body,
+      draft: input.draft,
+    });
+
+    return buildSendEnvelope(
+      account,
+      "send",
+      result.status,
+      subject,
+      recipientsFromInput(recipients),
+      result.refs,
+      null,
+    );
   }
 
   async reply(
     account: MailAccount,
     messageRef: string,
-    _input: ReplyInput,
-    _context: ProviderContext,
+    input: ReplyInput,
+    context: ProviderContext,
   ): Promise<SendResultEnvelope> {
-    notImplemented(`IMAP/SMTP reply is not implemented yet for '${messageRef}'.`, account.name);
+    const target = await resolveComposeTarget(account, context, messageRef);
+    const selfEmails = accountIdentityEmails(account, context);
+    const replyTo = emailsFromAddressObject(target.parsed.replyTo);
+    const from = emailsFromAddressObject(target.parsed.from);
+    let to = normalizeEmailList(withoutAccountEmails([...replyTo, ...from], selfEmails));
+    if (to.length === 0) {
+      to = normalizeEmailList(withoutAccountEmails(emailsFromAddressObject(target.parsed.to), selfEmails));
+    }
+    const recipients = {
+      to,
+      cc: normalizeEmailList(input.cc),
+      bcc: normalizeEmailList(input.bcc),
+    };
+    if (recipients.to.length === 0) {
+      throw new SurfaceError("unsupported", `Message '${messageRef}' does not expose a reply target.`, {
+        account: account.name,
+        messageRef,
+        threadRef: target.stored.thread_ref,
+      });
+    }
+
+    assertWriteAllowed(context.config, account, recipients, {
+      disposition: input.draft ? "draft" : "send",
+    });
+
+    const subject = prefixSubject(target.stored.subject ?? target.parsed.subject ?? "", "Re");
+    const result = await sendOrDraftImapSmtpMessage({
+      account,
+      context,
+      recipients,
+      subject,
+      body: buildReplyBody(input.body, target.stored),
+      draft: input.draft,
+      inReplyTo: target.messageId,
+      references: replyReferences(target),
+    });
+
+    return buildSendEnvelope(
+      account,
+      "reply",
+      result.status,
+      subject,
+      recipientsFromInput(recipients),
+      result.refs,
+      messageRef,
+    );
   }
 
   async replyAll(
     account: MailAccount,
     messageRef: string,
-    _input: ReplyInput,
-    _context: ProviderContext,
+    input: ReplyInput,
+    context: ProviderContext,
   ): Promise<SendResultEnvelope> {
-    notImplemented(`IMAP/SMTP reply-all is not implemented yet for '${messageRef}'.`, account.name);
+    const target = await resolveComposeTarget(account, context, messageRef);
+    const selfEmails = accountIdentityEmails(account, context);
+    const replyTo = emailsFromAddressObject(target.parsed.replyTo);
+    const from = emailsFromAddressObject(target.parsed.from);
+    const originalTo = emailsFromAddressObject(target.parsed.to);
+    const originalCc = emailsFromAddressObject(target.parsed.cc);
+
+    let to = normalizeEmailList(withoutAccountEmails([...replyTo, ...from], selfEmails));
+    if (to.length === 0) {
+      to = normalizeEmailList(withoutAccountEmails(originalTo, selfEmails));
+    }
+    if (to.length === 0) {
+      to = normalizeEmailList(from);
+    }
+
+    const toComparable = new Set(to.map(normalizeComparableEmail));
+    const cc = normalizeEmailList([
+      ...withoutAccountEmails(originalTo, selfEmails).filter((email) => !toComparable.has(normalizeComparableEmail(email))),
+      ...withoutAccountEmails(originalCc, selfEmails).filter((email) => !toComparable.has(normalizeComparableEmail(email))),
+      ...input.cc,
+    ]);
+    const recipients = {
+      to,
+      cc,
+      bcc: normalizeEmailList(input.bcc),
+    };
+    if (recipients.to.length === 0) {
+      throw new SurfaceError("unsupported", `Message '${messageRef}' does not expose reply-all recipients.`, {
+        account: account.name,
+        messageRef,
+        threadRef: target.stored.thread_ref,
+      });
+    }
+
+    assertWriteAllowed(context.config, account, recipients, {
+      disposition: input.draft ? "draft" : "send",
+    });
+
+    const subject = prefixSubject(target.stored.subject ?? target.parsed.subject ?? "", "Re");
+    const result = await sendOrDraftImapSmtpMessage({
+      account,
+      context,
+      recipients,
+      subject,
+      body: buildReplyBody(input.body, target.stored),
+      draft: input.draft,
+      inReplyTo: target.messageId,
+      references: replyReferences(target),
+    });
+
+    return buildSendEnvelope(
+      account,
+      "reply-all",
+      result.status,
+      subject,
+      recipientsFromInput(recipients),
+      result.refs,
+      messageRef,
+    );
   }
 
   async forward(
     account: MailAccount,
     messageRef: string,
-    _input: ForwardInput,
-    _context: ProviderContext,
+    input: ForwardInput,
+    context: ProviderContext,
   ): Promise<SendResultEnvelope> {
-    notImplemented(`IMAP/SMTP forward is not implemented yet for '${messageRef}'.`, account.name);
+    const target = await resolveComposeTarget(account, context, messageRef);
+    const recipients = {
+      to: normalizeEmailList(input.to),
+      cc: normalizeEmailList(input.cc),
+      bcc: normalizeEmailList(input.bcc),
+    };
+    if (recipients.to.length === 0) {
+      throw new SurfaceError("invalid_argument", "IMAP/SMTP forward requires at least one --to recipient.", {
+        account: account.name,
+        messageRef,
+        threadRef: target.stored.thread_ref,
+      });
+    }
+
+    assertWriteAllowed(context.config, account, recipients, {
+      disposition: input.draft ? "draft" : "send",
+    });
+
+    const subject = prefixSubject(target.stored.subject ?? target.parsed.subject ?? "", "Fwd");
+    const result = await sendOrDraftImapSmtpMessage({
+      account,
+      context,
+      recipients,
+      subject,
+      body: buildForwardBody(input.body, target.stored),
+      draft: input.draft,
+    });
+
+    return buildSendEnvelope(
+      account,
+      "forward",
+      result.status,
+      subject,
+      recipientsFromInput(recipients),
+      result.refs,
+      messageRef,
+    );
   }
 
   async archive(

--- a/src/providers/imap/adapter.ts
+++ b/src/providers/imap/adapter.ts
@@ -1,3 +1,22 @@
+import { Buffer } from "node:buffer";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  ImapFlow,
+  type FetchMessageObject,
+  type ListResponse,
+  type MailboxObject,
+  type SearchObject,
+} from "imapflow";
+import {
+  simpleParser,
+  type AddressObject,
+  type Attachment,
+  type EmailAddress,
+  type ParsedMail,
+} from "mailparser";
+
 import type { MailAccount } from "../../contracts/account.js";
 import type {
   ArchiveResultEnvelope,
@@ -6,6 +25,11 @@ import type {
   FetchUnreadQuery,
   ForwardInput,
   MarkMessagesResultEnvelope,
+  MessageEnvelope,
+  MessageInvite,
+  MessageParticipant,
+  NormalizedAttachmentRecord,
+  NormalizedMessageRecord,
   NormalizedThreadRecord,
   ReadResultEnvelope,
   ReplyInput,
@@ -16,10 +40,1182 @@ import type {
   SendResultEnvelope,
   SentMessageResult,
   SentQuery,
+  ThreadParticipant,
 } from "../../contracts/mail.js";
 import { SurfaceError, notImplemented } from "../../lib/errors.js";
+import { toPublicSentMessage } from "../../lib/public-mail.js";
+import { messageMatchesRecipient, normalizeComparableEmail, sentMessagesFromStoredThread } from "../../lib/sent-mail.js";
+import { assertWriteAllowed } from "../../lib/write-safety.js";
+import { makeAttachmentId, makeMessageRef, makeThreadRef } from "../../refs.js";
+import { summarizeAndPersistThreads } from "../../summarizer.js";
+import type { StoredMessageRecord } from "../../state/database.js";
 import type { AuthStatus, MailProviderAdapter, ProviderContext } from "../types.js";
+import { htmlToText } from "../shared/html.js";
+import { annotateBodyWithInlineAttachments } from "../shared/inline-attachments.js";
 import { clearImapSmtpAuthState, readImapSmtpAuthState, writeImapSmtpAuthState } from "./auth.js";
+
+const DEFAULT_MAILBOX = "INBOX";
+const MAX_FETCH_BATCH = 25;
+const ARCHIVE_RECOVERY_SCAN_LIMIT = 100;
+
+interface ImapMessageLocator {
+  [key: string]: string | number | null;
+  mailbox: string;
+  uid_validity: string;
+  uid: number;
+  message_id: string | null;
+  in_reply_to: string | null;
+  references: string | null;
+}
+
+interface ImapThreadLocator {
+  [key: string]: string | number | null;
+  mailbox: string;
+  uid_validity: string;
+  uid: number;
+}
+
+interface ImapAttachmentLocator {
+  [key: string]: string | number | null;
+  mailbox: string;
+  uid_validity: string;
+  uid: number;
+  index: number;
+  checksum: string | null;
+  filename: string | null;
+}
+
+function sourceInfo(account: MailAccount) {
+  return {
+    provider: account.provider,
+    transport: account.transport,
+  } as const;
+}
+
+function securityOptions(mode: "tls" | "starttls" | "none"): Pick<ConstructorParameters<typeof ImapFlow>[0], "secure" | "doSTARTTLS"> {
+  switch (mode) {
+    case "tls":
+      return { secure: true };
+    case "starttls":
+      return { secure: false, doSTARTTLS: true };
+    case "none":
+      return { secure: false, doSTARTTLS: false };
+  }
+}
+
+async function withImapClient<T>(
+  account: MailAccount,
+  context: ProviderContext,
+  work: (client: ImapFlow) => Promise<T>,
+): Promise<T> {
+  const state = readImapSmtpAuthState(account, context);
+  const client = new ImapFlow({
+    host: state.imap.host,
+    port: state.imap.port,
+    ...securityOptions(state.imap.security),
+    auth: {
+      user: state.username,
+      pass: state.password,
+    },
+    connectionTimeout: context.config.providerTimeoutMs,
+    greetingTimeout: context.config.providerTimeoutMs,
+    socketTimeout: context.config.providerTimeoutMs,
+    disableAutoIdle: true,
+    logger: false,
+  });
+
+  try {
+    await client.connect();
+    return await work(client);
+  } finally {
+    try {
+      if (client.usable) {
+        await client.logout();
+      } else {
+        client.close();
+      }
+    } catch {
+      client.close();
+    }
+  }
+}
+
+function normalizeMailboxAlias(value: string | undefined): string {
+  const normalized = (value ?? "inbox").trim().toLowerCase();
+  if (!normalized) {
+    return "inbox";
+  }
+  switch (normalized) {
+    case "inbox":
+      return "inbox";
+    case "sent":
+    case "sent-mail":
+    case "sent mail":
+    case "sent items":
+      return "sent";
+    case "archive":
+    case "archives":
+    case "all mail":
+      return "archive";
+    case "draft":
+    case "drafts":
+      return "drafts";
+    case "trash":
+    case "bin":
+    case "deleted":
+    case "deleted items":
+      return "trash";
+    case "spam":
+    case "junk":
+    case "junk mail":
+      return "spam";
+    default:
+      return value?.trim() ?? DEFAULT_MAILBOX;
+  }
+}
+
+function specialUseMatches(mailbox: ListResponse, expected: string): boolean {
+  return mailbox.specialUse?.trim().toLowerCase() === expected.toLowerCase();
+}
+
+function mailboxNameMatches(mailbox: ListResponse, names: string[]): boolean {
+  const candidates = [mailbox.path, mailbox.name].map((entry) => entry.trim().toLowerCase());
+  return names.some((name) => candidates.includes(name.trim().toLowerCase()));
+}
+
+function mailboxLabel(mailbox: string): string {
+  const normalized = mailbox.trim().toLowerCase();
+  switch (normalized) {
+    case "inbox":
+      return "inbox";
+    case "sent":
+    case "sent mail":
+    case "sent items":
+      return "sent";
+    case "archive":
+    case "archives":
+    case "all mail":
+      return "archive";
+    case "draft":
+    case "drafts":
+      return "drafts";
+    case "trash":
+    case "bin":
+    case "deleted items":
+      return "trash";
+    case "spam":
+    case "junk":
+    case "junk mail":
+      return "spam";
+    default:
+      return normalized || "inbox";
+  }
+}
+
+function resolveMailboxPath(mailboxes: ListResponse[], requested: string | undefined): string {
+  const alias = normalizeMailboxAlias(requested);
+  const specialUsesByAlias: Record<string, string[]> = {
+    inbox: ["\\Inbox"],
+    sent: ["\\Sent"],
+    archive: ["\\Archive", "\\All"],
+    drafts: ["\\Drafts"],
+    trash: ["\\Trash"],
+    spam: ["\\Junk"],
+  };
+  const namesByAlias: Record<string, string[]> = {
+    inbox: ["inbox"],
+    sent: ["sent", "sent mail", "sent items"],
+    archive: ["archive", "archives", "all mail"],
+    drafts: ["draft", "drafts"],
+    trash: ["trash", "bin", "deleted", "deleted items"],
+    spam: ["spam", "junk", "junk mail"],
+  };
+
+  const specialUses = specialUsesByAlias[alias];
+  if (specialUses) {
+    const matched = mailboxes.find((mailbox) =>
+      specialUses.some((specialUse) => specialUseMatches(mailbox, specialUse)));
+    if (matched) {
+      return matched.path;
+    }
+  }
+
+  const names = namesByAlias[alias];
+  if (names) {
+    const matched = mailboxes.find((mailbox) => mailboxNameMatches(mailbox, names));
+    if (matched) {
+      return matched.path;
+    }
+  }
+
+  const exact = mailboxes.find((mailbox) => mailbox.path.trim().toLowerCase() === alias.trim().toLowerCase());
+  if (exact) {
+    return exact.path;
+  }
+
+  return alias === "inbox" ? DEFAULT_MAILBOX : alias;
+}
+
+function imapThreadProviderKey(locator: ImapThreadLocator): string {
+  return `imap-thread:${locator.mailbox}:${locator.uid_validity}:${locator.uid}`;
+}
+
+function imapMessageProviderKey(locator: ImapMessageLocator): string {
+  return `imap-message:${locator.mailbox}:${locator.uid_validity}:${locator.uid}`;
+}
+
+function imapAttachmentProviderKey(messageLocator: ImapMessageLocator, attachment: NormalizedAttachmentRecord, index: number): string {
+  const checksum = attachment.locator?.locator.checksum;
+  if (typeof checksum === "string" && checksum) {
+    return `imap-attachment:${messageLocator.mailbox}:${messageLocator.uid_validity}:${messageLocator.uid}:${checksum}`;
+  }
+  return `imap-attachment:${messageLocator.mailbox}:${messageLocator.uid_validity}:${messageLocator.uid}:${attachment.filename}:${index}`;
+}
+
+function parseThreadLocator(locatorJson: string): ImapThreadLocator {
+  const parsed = JSON.parse(locatorJson) as Record<string, unknown>;
+  return {
+    mailbox: typeof parsed.mailbox === "string" && parsed.mailbox ? parsed.mailbox : DEFAULT_MAILBOX,
+    uid_validity: typeof parsed.uid_validity === "string" && parsed.uid_validity ? parsed.uid_validity : "",
+    uid: typeof parsed.uid === "number" ? parsed.uid : 0,
+  };
+}
+
+function parseMessageLocator(locatorJson: string): ImapMessageLocator {
+  const parsed = JSON.parse(locatorJson) as Record<string, unknown>;
+  return {
+    mailbox: typeof parsed.mailbox === "string" && parsed.mailbox ? parsed.mailbox : DEFAULT_MAILBOX,
+    uid_validity: typeof parsed.uid_validity === "string" && parsed.uid_validity ? parsed.uid_validity : "",
+    uid: typeof parsed.uid === "number" ? parsed.uid : 0,
+    message_id: typeof parsed.message_id === "string" && parsed.message_id ? parsed.message_id : null,
+    in_reply_to: typeof parsed.in_reply_to === "string" && parsed.in_reply_to ? parsed.in_reply_to : null,
+    references: typeof parsed.references === "string" && parsed.references ? parsed.references : null,
+  };
+}
+
+function parseAttachmentLocator(locatorJson: string): ImapAttachmentLocator {
+  const parsed = JSON.parse(locatorJson) as Record<string, unknown>;
+  return {
+    mailbox: typeof parsed.mailbox === "string" && parsed.mailbox ? parsed.mailbox : DEFAULT_MAILBOX,
+    uid_validity: typeof parsed.uid_validity === "string" && parsed.uid_validity ? parsed.uid_validity : "",
+    uid: typeof parsed.uid === "number" ? parsed.uid : 0,
+    index: typeof parsed.index === "number" ? parsed.index : -1,
+    checksum: typeof parsed.checksum === "string" && parsed.checksum ? parsed.checksum : null,
+    filename: typeof parsed.filename === "string" && parsed.filename ? parsed.filename : null,
+  };
+}
+
+function uidValidityString(mailbox: MailboxObject): string {
+  return mailbox.uidValidity.toString();
+}
+
+function participantFromAddress(address: EmailAddress | undefined): MessageParticipant {
+  return {
+    name: address?.name ?? address?.address ?? "",
+    email: address?.address ?? "",
+  };
+}
+
+function addressesFromObject(value: AddressObject | AddressObject[] | undefined): MessageParticipant[] {
+  const values = Array.isArray(value) ? value : value ? [value] : [];
+  return values.flatMap((entry) => entry.value.map(participantFromAddress));
+}
+
+function firstAddressFromObject(value: AddressObject | undefined): MessageParticipant | null {
+  const first = value?.value[0];
+  if (!first) {
+    return null;
+  }
+  return participantFromAddress(first);
+}
+
+function uniqueParticipants(messages: MessageEnvelope[]): ThreadParticipant[] {
+  const seen = new Set<string>();
+  const participants: ThreadParticipant[] = [];
+
+  const push = (role: ThreadParticipant["role"], mailbox: MessageParticipant | null | undefined) => {
+    if (!mailbox || (!mailbox.email && !mailbox.name)) {
+      return;
+    }
+    const key = `${role}:${mailbox.email}:${mailbox.name}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    participants.push({
+      role,
+      name: mailbox.name,
+      email: mailbox.email,
+    });
+  };
+
+  for (const message of messages) {
+    push("from", message.from);
+    for (const mailbox of message.to) {
+      push("to", mailbox);
+    }
+    for (const mailbox of message.cc) {
+      push("cc", mailbox);
+    }
+  }
+
+  return participants;
+}
+
+function flagsToLabels(mailbox: string, flags: Set<string> | undefined): string[] {
+  const labels = new Set<string>([mailboxLabel(mailbox)]);
+  if (!flags?.has("\\Seen")) {
+    labels.add("unread");
+  }
+  if (flags?.has("\\Flagged")) {
+    labels.add("flagged");
+  }
+  if (flags?.has("\\Answered")) {
+    labels.add("answered");
+  }
+  if (flags?.has("\\Draft")) {
+    labels.add("draft");
+  }
+  return [...labels];
+}
+
+function referencesToString(value: string[] | string | undefined): string | null {
+  if (Array.isArray(value)) {
+    const joined = value.filter(Boolean).join(" ").trim();
+    return joined || null;
+  }
+  return value?.trim() || null;
+}
+
+function messageBodyText(parsed: ParsedMail): string {
+  const text = parsed.text?.replace(/\r\n/g, "\n").trim();
+  if (text) {
+    return text;
+  }
+  if (typeof parsed.html === "string") {
+    return htmlToText(parsed.html);
+  }
+  return "";
+}
+
+function snippetFromBody(bodyText: string, fallback: string | undefined): string {
+  const normalized = bodyText.replace(/\s+/gu, " ").trim();
+  return (normalized || fallback || "").slice(0, 240);
+}
+
+function normalizeAttachment(
+  attachment: Attachment,
+  messageLocator: ImapMessageLocator,
+  index: number,
+): NormalizedAttachmentRecord {
+  const filename = attachment.filename?.trim() || `attachment-${index + 1}`;
+  return {
+    attachment_id: "",
+    filename,
+    mime_type: attachment.contentType || "application/octet-stream",
+    size_bytes: typeof attachment.size === "number" ? attachment.size : null,
+    inline: attachment.contentDisposition?.toLowerCase() === "inline" || attachment.related === true,
+    locator: {
+      kind: "attachment",
+      locator: {
+        mailbox: messageLocator.mailbox,
+        uid_validity: messageLocator.uid_validity,
+        uid: messageLocator.uid,
+        index,
+        checksum: attachment.checksum || null,
+        filename,
+      },
+    },
+  };
+}
+
+async function normalizeFetchedMessage(
+  account: MailAccount,
+  mailboxPath: string,
+  uidValidity: string,
+  fetched: FetchMessageObject,
+): Promise<NormalizedThreadRecord> {
+  if (!fetched.source) {
+    throw new SurfaceError("transport_error", "IMAP fetch did not return message source.", {
+      account: account.name,
+    });
+  }
+
+  const parsed = await simpleParser(fetched.source);
+  const messageLocator: ImapMessageLocator = {
+    mailbox: mailboxPath,
+    uid_validity: uidValidity,
+    uid: fetched.uid,
+    message_id: parsed.messageId ?? fetched.envelope?.messageId ?? null,
+    in_reply_to: parsed.inReplyTo ?? fetched.envelope?.inReplyTo ?? null,
+    references: referencesToString(parsed.references),
+  };
+  const threadLocator: ImapThreadLocator = {
+    mailbox: mailboxPath,
+    uid_validity: uidValidity,
+    uid: fetched.uid,
+  };
+
+  const bodyWithoutInlineMarkers = messageBodyText(parsed);
+  const attachments = parsed.attachments.map((attachment, index) => normalizeAttachment(attachment, messageLocator, index));
+  const bodyText = annotateBodyWithInlineAttachments(bodyWithoutInlineMarkers, attachments);
+  const sentAt = parsed.date?.toISOString() ?? dateToIso(fetched.envelope?.date) ?? dateToIso(fetched.internalDate);
+  const receivedAt = dateToIso(fetched.internalDate) ?? sentAt;
+  const subject = parsed.subject ?? fetched.envelope?.subject ?? "";
+  const unread = !fetched.flags?.has("\\Seen");
+  const labels = flagsToLabels(mailboxPath, fetched.flags);
+  const envelope: MessageEnvelope = {
+    from: firstAddressFromObject(parsed.from),
+    to: addressesFromObject(parsed.to),
+    cc: addressesFromObject(parsed.cc),
+    sent_at: sentAt,
+    received_at: receivedAt,
+    unread,
+    ...(subject ? { subject } : {}),
+  };
+
+  const message: NormalizedMessageRecord = {
+    message_ref: "",
+    envelope,
+    snippet: snippetFromBody(bodyText, fetched.envelope?.subject),
+    body: {
+      text: bodyText,
+      truncated: false,
+      cached: true,
+      cached_bytes: Buffer.byteLength(bodyText, "utf8"),
+    },
+    attachments,
+    provider_ids: {
+      message_id: `${mailboxPath}:${uidValidity}:${fetched.uid}`,
+      ...(messageLocator.message_id ? { internet_message_id: messageLocator.message_id } : {}),
+    },
+    locator: {
+      kind: "message",
+      locator: messageLocator,
+    },
+  };
+
+  return {
+    thread_ref: "",
+    source: sourceInfo(account),
+    envelope: {
+      subject,
+      participants: uniqueParticipants([envelope]),
+      mailbox: mailboxLabel(mailboxPath),
+      labels,
+      received_at: receivedAt,
+      message_count: 1,
+      unread_count: unread ? 1 : 0,
+      has_attachments: attachments.length > 0,
+    },
+    summary: null,
+    messages: [message],
+    provider_ids: {
+      thread_id: `${mailboxPath}:${uidValidity}:${fetched.uid}`,
+    },
+    locator: {
+      kind: "thread",
+      locator: threadLocator,
+    },
+  };
+}
+
+function dateToIso(value: Date | string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+function parseStoredMessage(record: StoredMessageRecord) {
+  const envelope: MessageEnvelope = {
+    from:
+      record.from_name || record.from_email
+        ? {
+            name: record.from_name ?? "",
+            email: record.from_email ?? "",
+          }
+        : null,
+    to: JSON.parse(record.to_json) as MessageParticipant[],
+    cc: JSON.parse(record.cc_json) as MessageParticipant[],
+    sent_at: record.sent_at,
+    received_at: record.received_at,
+    unread: Boolean(record.unread),
+    ...(record.subject ? { subject: record.subject } : {}),
+  };
+
+  return {
+    envelope,
+    body: {
+      text: record.body_cache_path && existsSync(record.body_cache_path) ? readFileSync(record.body_cache_path, "utf8") : "",
+      truncated: Boolean(record.body_truncated),
+      cached: Boolean(record.body_cached),
+      cached_bytes: record.body_cached_bytes,
+    },
+    invite: record.invite_json ? JSON.parse(record.invite_json) as MessageInvite : undefined,
+  };
+}
+
+function buildReadEnvelope(
+  account: MailAccount,
+  messageRef: string,
+  threadRef: string,
+  parsed: ReturnType<typeof parseStoredMessage>,
+  attachments: AttachmentListEnvelope["attachments"],
+  cacheStatus: ReadResultEnvelope["cache"]["status"],
+): ReadResultEnvelope {
+  return {
+    schema_version: "1",
+    command: "read",
+    account: account.name,
+    message_ref: messageRef,
+    thread_ref: threadRef,
+    source: sourceInfo(account),
+    cache: {
+      status: cacheStatus,
+      truncated: parsed.body.truncated,
+    },
+    message: {
+      envelope: parsed.envelope,
+      body: parsed.body,
+      attachments,
+      ...(parsed.invite ? { invite: parsed.invite } : {}),
+    },
+  };
+}
+
+function buildArchiveEnvelope(account: MailAccount, messageRef: string, threadRef: string): ArchiveResultEnvelope {
+  return {
+    schema_version: "1",
+    command: "archive",
+    account: account.name,
+    message_ref: messageRef,
+    thread_ref: threadRef,
+    source: sourceInfo(account),
+    status: "archived",
+  };
+}
+
+function buildMarkMessagesEnvelope(
+  account: MailAccount,
+  command: MarkMessagesResultEnvelope["command"],
+  updated: MarkMessagesResultEnvelope["updated"],
+): MarkMessagesResultEnvelope {
+  return {
+    schema_version: "1",
+    command,
+    account: account.name,
+    source: sourceInfo(account),
+    updated,
+  };
+}
+
+interface PersistThreadOverrides {
+  threadRefsByProviderKey?: Map<string, string>;
+  messageRefsByProviderKey?: Map<string, string>;
+  attachmentRefsByProviderKey?: Map<string, string>;
+}
+
+function persistThreads(
+  account: MailAccount,
+  context: ProviderContext,
+  threads: NormalizedThreadRecord[],
+  overrides: PersistThreadOverrides = {},
+): NormalizedThreadRecord[] {
+  return context.db.transaction(() => {
+    const persistedThreads: NormalizedThreadRecord[] = [];
+
+    for (const thread of threads) {
+      const threadLocator = thread.locator?.locator as ImapThreadLocator | undefined;
+      if (!threadLocator?.uid || !threadLocator.uid_validity) {
+        throw new SurfaceError("transport_error", "IMAP thread is missing UID locator data.", {
+          account: account.name,
+        });
+      }
+
+      const threadProviderKey = imapThreadProviderKey(threadLocator);
+      const resolvedThreadRef =
+        overrides.threadRefsByProviderKey?.get(threadProviderKey)
+        ?? context.db.findEntityRefByProviderKey("thread", account.account_id, threadProviderKey)
+        ?? makeThreadRef();
+
+      context.db.upsertThread({
+        thread_ref: resolvedThreadRef,
+        account_id: account.account_id,
+        subject: thread.envelope.subject,
+        participants: thread.envelope.participants,
+        mailbox: thread.envelope.mailbox,
+        labels: thread.envelope.labels,
+        received_at: thread.envelope.received_at,
+        message_count: thread.envelope.message_count,
+        unread_count: thread.envelope.unread_count,
+        has_attachments: thread.envelope.has_attachments,
+      });
+      context.db.upsertProviderLocator({
+        entity_kind: "thread",
+        entity_ref: resolvedThreadRef,
+        account_id: account.account_id,
+        provider_key: threadProviderKey,
+        locator_json: JSON.stringify(threadLocator),
+      });
+
+      const persistedMessages: NormalizedMessageRecord[] = [];
+      const messageRefs: string[] = [];
+      for (const message of thread.messages) {
+        const messageLocator = message.locator?.locator as ImapMessageLocator | undefined;
+        if (!messageLocator?.uid || !messageLocator.uid_validity) {
+          throw new SurfaceError("transport_error", "IMAP message is missing UID locator data.", {
+            account: account.name,
+            threadRef: resolvedThreadRef,
+          });
+        }
+
+        const messageProviderKey = imapMessageProviderKey(messageLocator);
+        const resolvedMessageRef =
+          overrides.messageRefsByProviderKey?.get(messageProviderKey)
+          ?? context.db.findEntityRefByProviderKey("message", account.account_id, messageProviderKey)
+          ?? makeMessageRef();
+
+        const messageDir = join(context.accountPaths.messagesDir, resolvedMessageRef);
+        mkdirSync(messageDir, { recursive: true });
+        const bodyCachePath = join(messageDir, "body.txt");
+        writeFileSync(bodyCachePath, message.body.text, "utf8");
+
+        context.db.upsertMessage({
+          message_ref: resolvedMessageRef,
+          account_id: account.account_id,
+          thread_ref: resolvedThreadRef,
+          subject: message.envelope.subject ?? thread.envelope.subject,
+          from_name: message.envelope.from?.name ?? null,
+          from_email: message.envelope.from?.email ?? null,
+          to_json: JSON.stringify(message.envelope.to),
+          cc_json: JSON.stringify(message.envelope.cc),
+          sent_at: message.envelope.sent_at,
+          received_at: message.envelope.received_at,
+          unread: message.envelope.unread,
+          snippet: message.snippet,
+          body_cache_path: bodyCachePath,
+          body_cached: true,
+          body_truncated: message.body.truncated,
+          body_cached_bytes: Buffer.byteLength(message.body.text, "utf8"),
+          invite_json: message.invite ? JSON.stringify(message.invite) : null,
+        });
+        context.db.upsertProviderLocator({
+          entity_kind: "message",
+          entity_ref: resolvedMessageRef,
+          account_id: account.account_id,
+          provider_key: messageProviderKey,
+          locator_json: JSON.stringify(messageLocator),
+        });
+
+        const persistedAttachments: NormalizedAttachmentRecord[] = [];
+        for (const [index, attachment] of message.attachments.entries()) {
+          const providerKey = imapAttachmentProviderKey(messageLocator, attachment, index);
+          const resolvedAttachmentId =
+            overrides.attachmentRefsByProviderKey?.get(providerKey)
+            ?? context.db.findEntityRefByProviderKey("attachment", account.account_id, providerKey)
+            ?? makeAttachmentId();
+          const attachmentLocator = attachment.locator?.locator as ImapAttachmentLocator | undefined;
+          context.db.upsertProviderLocator({
+            entity_kind: "attachment",
+            entity_ref: resolvedAttachmentId,
+            account_id: account.account_id,
+            provider_key: providerKey,
+            locator_json: JSON.stringify(attachmentLocator ?? {}),
+          });
+          persistedAttachments.push({
+            ...attachment,
+            attachment_id: resolvedAttachmentId,
+          });
+        }
+
+        context.db.replaceAttachments(
+          resolvedMessageRef,
+          persistedAttachments.map((attachment) => ({
+            attachment_id: attachment.attachment_id,
+            filename: attachment.filename,
+            mime_type: attachment.mime_type,
+            size_bytes: attachment.size_bytes,
+            inline: attachment.inline,
+            saved_to: null,
+          })),
+        );
+
+        persistedMessages.push({
+          ...message,
+          message_ref: resolvedMessageRef,
+          body: {
+            ...message.body,
+            cached: true,
+            cached_bytes: Buffer.byteLength(message.body.text, "utf8"),
+          },
+          attachments: persistedAttachments,
+        });
+        messageRefs.push(resolvedMessageRef);
+      }
+
+      context.db.replaceThreadMessages(resolvedThreadRef, messageRefs);
+
+      persistedThreads.push({
+        ...thread,
+        thread_ref: resolvedThreadRef,
+        messages: persistedMessages,
+      });
+    }
+
+    return persistedThreads;
+  });
+}
+
+async function fetchUidThreads(
+  account: MailAccount,
+  client: ImapFlow,
+  mailboxPath: string,
+  uids: number[],
+): Promise<NormalizedThreadRecord[]> {
+  if (uids.length === 0) {
+    return [];
+  }
+  const mailbox = await client.mailboxOpen(mailboxPath);
+  const uidValidity = uidValidityString(mailbox);
+  const threads: NormalizedThreadRecord[] = [];
+  const batches: number[][] = [];
+  for (let index = 0; index < uids.length; index += MAX_FETCH_BATCH) {
+    batches.push(uids.slice(index, index + MAX_FETCH_BATCH));
+  }
+
+  for (const batch of batches) {
+    for await (const fetched of client.fetch(batch, {
+      source: true,
+      envelope: true,
+      flags: true,
+      internalDate: true,
+      size: true,
+      threadId: true,
+    }, { uid: true })) {
+      threads.push(await normalizeFetchedMessage(account, mailboxPath, uidValidity, fetched));
+    }
+  }
+
+  return threads.sort((left, right) =>
+    Date.parse(right.envelope.received_at ?? "") - Date.parse(left.envelope.received_at ?? ""),
+  );
+}
+
+function sameIsoInstant(left: string | null, right: string | null): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(leftMs) || !Number.isFinite(rightMs)) {
+    return left === right;
+  }
+  return Math.abs(leftMs - rightMs) <= 1000;
+}
+
+function archivedThreadMatchesStoredMessage(
+  stored: StoredMessageRecord,
+  sourceLocator: ImapMessageLocator,
+  thread: NormalizedThreadRecord,
+): boolean {
+  const message = thread.messages[0];
+  const messageLocator = message?.locator?.locator as ImapMessageLocator | undefined;
+  if (!message || !messageLocator) {
+    return false;
+  }
+
+  if (sourceLocator.message_id && messageLocator.message_id === sourceLocator.message_id) {
+    return true;
+  }
+
+  if ((stored.subject ?? "") !== (message.envelope.subject ?? "")) {
+    return false;
+  }
+  if (normalizeComparableEmail(stored.from_email) !== normalizeComparableEmail(message.envelope.from?.email)) {
+    return false;
+  }
+
+  const sentAtMatches = sameIsoInstant(stored.sent_at, message.envelope.sent_at);
+  const receivedAtMatches = sameIsoInstant(stored.received_at, message.envelope.received_at);
+  return sentAtMatches || receivedAtMatches || stored.snippet === message.snippet;
+}
+
+async function recoverArchivedThreadAfterMove(
+  account: MailAccount,
+  client: ImapFlow,
+  archivePath: string,
+  stored: StoredMessageRecord,
+  sourceLocator: ImapMessageLocator,
+  movedUid: number | undefined,
+): Promise<NormalizedThreadRecord | null> {
+  if (movedUid) {
+    const [movedThread] = await fetchUidThreads(account, client, archivePath, [movedUid]);
+    return movedThread ?? null;
+  }
+
+  if (sourceLocator.message_id) {
+    await client.mailboxOpen(archivePath);
+    const matches = await client.search({ header: { "message-id": sourceLocator.message_id } }, { uid: true });
+    const uids = Array.isArray(matches) ? matches.slice(-ARCHIVE_RECOVERY_SCAN_LIMIT).reverse() : [];
+    const threads = await fetchUidThreads(account, client, archivePath, uids);
+    const matched = threads.find((thread) => archivedThreadMatchesStoredMessage(stored, sourceLocator, thread));
+    if (matched) {
+      return matched;
+    }
+  }
+
+  await client.mailboxOpen(archivePath);
+  const all = await client.search({ all: true }, { uid: true });
+  const recentUids = Array.isArray(all) ? all.slice(-ARCHIVE_RECOVERY_SCAN_LIMIT).reverse() : [];
+  const recentThreads = await fetchUidThreads(account, client, archivePath, recentUids);
+  return recentThreads.find((thread) => archivedThreadMatchesStoredMessage(stored, sourceLocator, thread)) ?? null;
+}
+
+function buildSearchObject(query: SearchQuery): SearchObject {
+  const search: SearchObject = { all: true };
+  if (query.text?.trim()) {
+    search.text = query.text.trim();
+  }
+  if (query.from?.trim()) {
+    search.from = query.from.trim();
+  }
+  if (query.subject?.trim()) {
+    search.subject = query.subject.trim();
+  }
+  if (query.unread_only || query.labels?.some((label) => label.trim().toLowerCase() === "unread")) {
+    search.seen = false;
+  }
+  if (query.labels?.some((label) => ["read", "seen"].includes(label.trim().toLowerCase()))) {
+    search.seen = true;
+  }
+  if (query.labels?.some((label) => label.trim().toLowerCase() === "flagged")) {
+    search.flagged = true;
+  }
+  return search;
+}
+
+function buildSentSearch(query: SentQuery): { search: SearchObject; fetchLimit: number } {
+  const search: SearchObject = { all: true };
+  const fetchLimit = query.recipient?.trim() ? Math.min(Math.max(query.limit * 5, query.limit), 100) : query.limit;
+  if (query.recipient?.trim()) {
+    search.or = [
+      { to: query.recipient.trim() },
+      { cc: query.recipient.trim() },
+    ];
+  }
+  return { search, fetchLimit };
+}
+
+function filterSentMessagesForQuery(messages: SentMessageResult[], query: SentQuery): SentMessageResult[] {
+  return messages
+    .filter((message) => messageMatchesRecipient(message, query.recipient))
+    .slice(0, query.limit);
+}
+
+function threadMatchesLabels(thread: NormalizedThreadRecord, labels: string[] | undefined): boolean {
+  if ((labels?.length ?? 0) === 0) {
+    return true;
+  }
+  const available = new Set(thread.envelope.labels.map((label) => label.trim().toLowerCase()));
+  return labels?.every((label) => available.has(label.trim().toLowerCase())) ?? true;
+}
+
+async function searchMailbox(
+  account: MailAccount,
+  context: ProviderContext,
+  query: SearchQuery,
+): Promise<NormalizedThreadRecord[]> {
+  return withImapClient(account, context, async (client) => {
+    const mailboxes = await client.list();
+    const mailboxPath = resolveMailboxPath(mailboxes, query.mailbox);
+    await client.mailboxOpen(mailboxPath);
+    const matches = await client.search(buildSearchObject(query), { uid: true });
+    const uids = Array.isArray(matches) ? matches.slice(-query.limit).reverse() : [];
+    const normalized = await fetchUidThreads(account, client, mailboxPath, uids);
+    const persisted = persistThreads(account, context, normalized.filter((thread) => threadMatchesLabels(thread, query.labels)));
+    return summarizeAndPersistThreads(persisted, context.config, context.db, context.db.getAccountIdentity(account));
+  });
+}
+
+async function fetchUnreadMailbox(
+  account: MailAccount,
+  context: ProviderContext,
+  query: FetchUnreadQuery,
+): Promise<NormalizedThreadRecord[]> {
+  return withImapClient(account, context, async (client) => {
+    const mailboxPath = resolveMailboxPath(await client.list(), "inbox");
+    await client.mailboxOpen(mailboxPath);
+    const matches = await client.search({ seen: false }, { uid: true });
+    const uids = Array.isArray(matches) ? matches.slice(-query.limit).reverse() : [];
+    const normalized = await fetchUidThreads(account, client, mailboxPath, uids);
+    const persisted = persistThreads(account, context, normalized);
+    return summarizeAndPersistThreads(persisted, context.config, context.db, context.db.getAccountIdentity(account));
+  });
+}
+
+async function refreshUidThread(
+  account: MailAccount,
+  context: ProviderContext,
+  locator: ImapThreadLocator | ImapMessageLocator,
+): Promise<NormalizedThreadRecord | null> {
+  return withImapClient(account, context, async (client) => {
+    const mailbox = await client.mailboxOpen(locator.mailbox);
+    if (uidValidityString(mailbox) !== locator.uid_validity) {
+      throw new SurfaceError("cache_miss", `IMAP UIDVALIDITY changed for mailbox '${locator.mailbox}'.`, {
+        account: account.name,
+      });
+    }
+    const fetched = await client.fetchOne(String(locator.uid), {
+      source: true,
+      envelope: true,
+      flags: true,
+      internalDate: true,
+      size: true,
+      threadId: true,
+    }, { uid: true });
+    if (!fetched) {
+      return null;
+    }
+    const normalized = await normalizeFetchedMessage(account, locator.mailbox, locator.uid_validity, fetched);
+    const [persisted] = persistThreads(account, context, [normalized]);
+    if (persisted) {
+      const [summarized] = await summarizeAndPersistThreads([persisted], context.config, context.db, context.db.getAccountIdentity(account));
+      return summarized ?? persisted;
+    }
+    return null;
+  });
+}
+
+async function refreshStoredMessage(
+  account: MailAccount,
+  messageRef: string,
+  context: ProviderContext,
+): Promise<StoredMessageRecord> {
+  const locatorRow = context.db.findProviderLocator("message", messageRef);
+  if (!locatorRow) {
+    throw new SurfaceError("cache_miss", `No provider locator exists for message '${messageRef}'.`, {
+      account: account.name,
+      messageRef,
+    });
+  }
+
+  const locator = parseMessageLocator(locatorRow.locator_json);
+  const refreshed = await refreshUidThread(account, context, locator);
+  if (!refreshed) {
+    throw new SurfaceError("not_found", `Message '${messageRef}' could not be refreshed from IMAP.`, {
+      account: account.name,
+      messageRef,
+    });
+  }
+  const stored = context.db.getStoredMessage(messageRef);
+  if (!stored) {
+    throw new SurfaceError("not_found", `Message '${messageRef}' was not found after IMAP refresh.`, {
+      account: account.name,
+      messageRef,
+    });
+  }
+  return stored;
+}
+
+function requireMessageForAccount(account: MailAccount, messageRef: string, context: ProviderContext): StoredMessageRecord {
+  const stored = context.db.getStoredMessage(messageRef);
+  if (!stored) {
+    throw new SurfaceError("not_found", `Message '${messageRef}' was not found.`, {
+      account: account.name,
+      messageRef,
+    });
+  }
+  if (stored.account_id !== account.account_id) {
+    throw new SurfaceError("invalid_argument", `Message '${messageRef}' does not belong to account '${account.name}'.`, {
+      account: account.name,
+      messageRef,
+      threadRef: stored.thread_ref,
+    });
+  }
+  return stored;
+}
+
+function attachmentMetas(context: ProviderContext, messageRef: string): AttachmentListEnvelope["attachments"] {
+  return context.db.listAttachmentsForMessage(messageRef).map((attachment) => ({
+    attachment_id: attachment.attachment_id,
+    filename: attachment.filename,
+    mime_type: attachment.mime_type,
+    size_bytes: attachment.size_bytes,
+    inline: Boolean(attachment.inline),
+  }));
+}
+
+function attachmentIdentityKeys(locator: ImapAttachmentLocator): string[] {
+  const keys: string[] = [];
+  if (locator.checksum) {
+    keys.push(`checksum:${locator.checksum}`);
+  }
+  keys.push(`position:${locator.index}:${(locator.filename ?? "").trim().toLowerCase()}`);
+  return keys;
+}
+
+function buildAttachmentRefOverrides(
+  context: ProviderContext,
+  messageRef: string,
+  messageLocator: ImapMessageLocator,
+  attachments: NormalizedAttachmentRecord[],
+): Map<string, string> {
+  const existingRefsByIdentity = new Map<string, string>();
+  for (const existing of context.db.listAttachmentsForMessage(messageRef)) {
+    const locatorRow = context.db.findProviderLocator("attachment", existing.attachment_id);
+    if (!locatorRow) {
+      continue;
+    }
+    const existingLocator = parseAttachmentLocator(locatorRow.locator_json);
+    for (const key of attachmentIdentityKeys(existingLocator)) {
+      existingRefsByIdentity.set(key, existing.attachment_id);
+    }
+  }
+
+  const refsByProviderKey = new Map<string, string>();
+  for (const [index, attachment] of attachments.entries()) {
+    const providerKey = imapAttachmentProviderKey(messageLocator, attachment, index);
+    const attachmentLocator = attachment.locator?.locator as ImapAttachmentLocator | undefined;
+    if (!attachmentLocator) {
+      continue;
+    }
+    const existingRef = attachmentIdentityKeys(attachmentLocator)
+      .map((key) => existingRefsByIdentity.get(key))
+      .find((ref): ref is string => Boolean(ref));
+    if (existingRef) {
+      refsByProviderKey.set(providerKey, existingRef);
+    }
+  }
+
+  return refsByProviderKey;
+}
+
+async function fetchSentMessages(
+  account: MailAccount,
+  context: ProviderContext,
+  query: SentQuery,
+): Promise<SentMessageResult[]> {
+  if (query.thread_ref) {
+    const locatorRow = context.db.findProviderLocator("thread", query.thread_ref);
+    if (locatorRow) {
+      await refreshUidThread(account, context, parseThreadLocator(locatorRow.locator_json));
+    }
+    return sentMessagesFromStoredThread(account, context, query);
+  }
+
+  return withImapClient(account, context, async (client) => {
+    const mailboxes = await client.list();
+    const sentPath = resolveMailboxPath(mailboxes, "sent");
+    await client.mailboxOpen(sentPath);
+    const { search, fetchLimit } = buildSentSearch(query);
+    const matches = await client.search(search, { uid: true });
+    const uids = Array.isArray(matches) ? matches.slice(-fetchLimit).reverse() : [];
+    const normalized = await fetchUidThreads(account, client, sentPath, uids);
+    const persisted = persistThreads(account, context, normalized);
+    const summarized = await summarizeAndPersistThreads(persisted, context.config, context.db, context.db.getAccountIdentity(account));
+    return filterSentMessagesForQuery(
+      summarized.flatMap((thread) => thread.messages.map((message) => toPublicSentMessage(thread, message))),
+      query,
+    );
+  });
+}
+
+function sanitizeAttachmentFilename(filename: string): string {
+  const sanitized = filename.replace(/[\\/:*?"<>|\u0000-\u001F]/gu, "_").trim();
+  return sanitized || "attachment";
+}
+
+async function readMessageSource(
+  account: MailAccount,
+  context: ProviderContext,
+  locator: ImapMessageLocator,
+): Promise<Buffer> {
+  return withImapClient(account, context, async (client) => {
+    const mailbox = await client.mailboxOpen(locator.mailbox);
+    if (uidValidityString(mailbox) !== locator.uid_validity) {
+      throw new SurfaceError("cache_miss", `IMAP UIDVALIDITY changed for mailbox '${locator.mailbox}'.`, {
+        account: account.name,
+      });
+    }
+    const fetched = await client.fetchOne(String(locator.uid), { source: true }, { uid: true });
+    if (!fetched || !fetched.source) {
+      throw new SurfaceError("not_found", `IMAP message '${locator.uid}' was not found in '${locator.mailbox}'.`, {
+        account: account.name,
+      });
+    }
+    return fetched.source;
+  });
+}
+
+async function mutateSeenFlag(
+  account: MailAccount,
+  context: ProviderContext,
+  messageRefs: string[],
+  unread: boolean,
+): Promise<MarkMessagesResultEnvelope["updated"]> {
+  const updated: MarkMessagesResultEnvelope["updated"] = [];
+  const touchedThreads = new Set<string>();
+
+  await withImapClient(account, context, async (client) => {
+    const targets = messageRefs.map((messageRef) => {
+      const stored = requireMessageForAccount(account, messageRef, context);
+      const locatorRow = context.db.findProviderLocator("message", messageRef);
+      if (!locatorRow) {
+        throw new SurfaceError("cache_miss", `No provider locator exists for message '${messageRef}'.`, {
+          account: account.name,
+          messageRef,
+          threadRef: stored.thread_ref,
+        });
+      }
+      return { messageRef, stored, locator: parseMessageLocator(locatorRow.locator_json) };
+    });
+
+    const byMailbox = new Map<string, typeof targets>();
+    for (const target of targets) {
+      byMailbox.set(target.locator.mailbox, [...(byMailbox.get(target.locator.mailbox) ?? []), target]);
+    }
+
+    for (const [mailboxPath, mailboxTargets] of byMailbox) {
+      const mailbox = await client.mailboxOpen(mailboxPath);
+      for (const target of mailboxTargets) {
+        if (uidValidityString(mailbox) !== target.locator.uid_validity) {
+          throw new SurfaceError("cache_miss", `IMAP UIDVALIDITY changed for mailbox '${mailboxPath}'.`, {
+            account: account.name,
+            messageRef: target.messageRef,
+            threadRef: target.stored.thread_ref,
+          });
+        }
+      }
+      const uids = mailboxTargets.map((target) => target.locator.uid);
+      if (unread) {
+        await client.messageFlagsRemove(uids, ["\\Seen"], { uid: true });
+      } else {
+        await client.messageFlagsAdd(uids, ["\\Seen"], { uid: true });
+      }
+      for (const target of mailboxTargets) {
+        updated.push({
+          message_ref: target.messageRef,
+          thread_ref: target.stored.thread_ref,
+          unread,
+        });
+        touchedThreads.add(target.stored.thread_ref);
+      }
+    }
+  });
+
+  context.db.updateMessagesUnreadState(messageRefs, unread);
+  context.db.recomputeThreadUnreadCounts([...touchedThreads]);
+  return updated;
+}
+
+export const imapAdapterTestHooks = {
+  archivedThreadMatchesStoredMessage,
+  buildSentSearch,
+  filterSentMessagesForQuery,
+  resolveMailboxPath,
+};
 
 export class ImapSmtpAdapter implements MailProviderAdapter {
   readonly provider = "imap" as const;
@@ -66,56 +1262,141 @@ export class ImapSmtpAdapter implements MailProviderAdapter {
 
   async search(
     account: MailAccount,
-    _query: SearchQuery,
-    _context: ProviderContext,
+    query: SearchQuery,
+    context: ProviderContext,
   ): Promise<NormalizedThreadRecord[]> {
-    notImplemented("IMAP search is not implemented yet.", account.name);
+    return searchMailbox(account, context, query);
   }
 
   async fetchUnread(
     account: MailAccount,
-    _query: FetchUnreadQuery,
-    _context: ProviderContext,
+    query: FetchUnreadQuery,
+    context: ProviderContext,
   ): Promise<NormalizedThreadRecord[]> {
-    notImplemented("IMAP fetch-unread is not implemented yet.", account.name);
+    return fetchUnreadMailbox(account, context, query);
   }
 
   async fetchSent(
     account: MailAccount,
-    _query: SentQuery,
-    _context: ProviderContext,
+    query: SentQuery,
+    context: ProviderContext,
   ): Promise<SentMessageResult[]> {
-    notImplemented("IMAP sent-mail lookup is not implemented yet.", account.name);
+    return fetchSentMessages(account, context, query);
   }
 
-  async refreshThread(account: MailAccount, threadRef: string, _context: ProviderContext): Promise<void> {
-    notImplemented(`IMAP thread refresh is not implemented yet for '${threadRef}'.`, account.name);
+  async refreshThread(account: MailAccount, threadRef: string, context: ProviderContext): Promise<void> {
+    const locatorRow = context.db.findProviderLocator("thread", threadRef);
+    if (!locatorRow) {
+      throw new SurfaceError("cache_miss", `No provider locator exists for thread '${threadRef}'.`, {
+        account: account.name,
+        threadRef,
+      });
+    }
+    await refreshUidThread(account, context, parseThreadLocator(locatorRow.locator_json));
   }
 
   async readMessage(
     account: MailAccount,
     messageRef: string,
-    _refresh: boolean,
-    _context: ProviderContext,
+    refresh: boolean,
+    context: ProviderContext,
   ): Promise<ReadResultEnvelope> {
-    notImplemented(`IMAP message read is not implemented yet for '${messageRef}'.`, account.name);
+    const stored = requireMessageForAccount(account, messageRef, context);
+    const attachments = attachmentMetas(context, messageRef);
+    const hasReadableCache = Boolean(stored.body_cache_path && existsSync(stored.body_cache_path));
+    if (!refresh && hasReadableCache) {
+      return buildReadEnvelope(account, messageRef, stored.thread_ref, parseStoredMessage(stored), attachments, "hit");
+    }
+
+    const refreshed = await refreshStoredMessage(account, messageRef, context);
+    return buildReadEnvelope(
+      account,
+      messageRef,
+      refreshed.thread_ref,
+      parseStoredMessage(refreshed),
+      attachmentMetas(context, messageRef),
+      hasReadableCache ? "refreshed" : "miss",
+    );
   }
 
   async listAttachments(
     account: MailAccount,
     messageRef: string,
-    _context: ProviderContext,
+    context: ProviderContext,
   ): Promise<AttachmentListEnvelope> {
-    notImplemented(`IMAP attachment list is not implemented yet for '${messageRef}'.`, account.name);
+    requireMessageForAccount(account, messageRef, context);
+    return {
+      schema_version: "1",
+      command: "attachment-list",
+      account: account.name,
+      message_ref: messageRef,
+      attachments: attachmentMetas(context, messageRef),
+    };
   }
 
   async downloadAttachment(
     account: MailAccount,
     messageRef: string,
     attachmentId: string,
-    _context: ProviderContext,
+    context: ProviderContext,
   ): Promise<AttachmentDownloadEnvelope> {
-    notImplemented(`IMAP attachment download is not implemented yet for '${messageRef}/${attachmentId}'.`, account.name);
+    requireMessageForAccount(account, messageRef, context);
+    const attachment = context.db.listAttachmentsForMessage(messageRef).find((entry) => entry.attachment_id === attachmentId);
+    if (!attachment) {
+      throw new SurfaceError("not_found", `Attachment '${attachmentId}' was not found for message '${messageRef}'.`, {
+        account: account.name,
+        messageRef,
+      });
+    }
+
+    const messageLocatorRow = context.db.findProviderLocator("message", messageRef);
+    const attachmentLocatorRow = context.db.findProviderLocator("attachment", attachmentId);
+    if (!messageLocatorRow || !attachmentLocatorRow) {
+      await refreshStoredMessage(account, messageRef, context);
+    }
+    const refreshedMessageLocatorRow = context.db.findProviderLocator("message", messageRef);
+    const refreshedAttachmentLocatorRow = context.db.findProviderLocator("attachment", attachmentId);
+    if (!refreshedMessageLocatorRow || !refreshedAttachmentLocatorRow) {
+      throw new SurfaceError("cache_miss", `No provider locator exists for attachment '${attachmentId}'.`, {
+        account: account.name,
+        messageRef,
+      });
+    }
+
+    const messageLocator = parseMessageLocator(refreshedMessageLocatorRow.locator_json);
+    const attachmentLocator = parseAttachmentLocator(refreshedAttachmentLocatorRow.locator_json);
+    const parsed = await simpleParser(await readMessageSource(account, context, messageLocator));
+    const matched = parsed.attachments.find((candidate, index) =>
+      (attachmentLocator.checksum && candidate.checksum === attachmentLocator.checksum)
+      || (attachmentLocator.index === index && (!attachmentLocator.filename || candidate.filename === attachmentLocator.filename)),
+    );
+    if (!matched) {
+      throw new SurfaceError("not_found", `Attachment '${attachmentId}' could not be found in IMAP message '${messageRef}'.`, {
+        account: account.name,
+        messageRef,
+      });
+    }
+
+    const targetDir = join(context.accountPaths.downloadsDir, messageRef);
+    mkdirSync(targetDir, { recursive: true });
+    const targetPath = join(targetDir, `${attachmentId}__${sanitizeAttachmentFilename(attachment.filename)}`);
+    writeFileSync(targetPath, matched.content);
+    context.db.updateAttachmentSavedTo(attachmentId, targetPath);
+
+    return {
+      schema_version: "1",
+      command: "attachment-download",
+      account: account.name,
+      message_ref: messageRef,
+      attachment: {
+        attachment_id: attachmentId,
+        filename: attachment.filename,
+        mime_type: attachment.mime_type,
+        size_bytes: attachment.size_bytes,
+        inline: Boolean(attachment.inline),
+        saved_to: targetPath,
+      },
+    };
   }
 
   async rsvp(
@@ -168,24 +1449,80 @@ export class ImapSmtpAdapter implements MailProviderAdapter {
   async archive(
     account: MailAccount,
     messageRef: string,
-    _context: ProviderContext,
+    context: ProviderContext,
   ): Promise<ArchiveResultEnvelope> {
-    notImplemented(`IMAP archive is not implemented yet for '${messageRef}'.`, account.name);
+    assertWriteAllowed(context.config, account, { to: [], cc: [], bcc: [] }, { disposition: "non_send" });
+    const stored = requireMessageForAccount(account, messageRef, context);
+    const locatorRow = context.db.findProviderLocator("message", messageRef);
+    if (!locatorRow) {
+      throw new SurfaceError("cache_miss", `No provider locator exists for message '${messageRef}'.`, {
+        account: account.name,
+        messageRef,
+        threadRef: stored.thread_ref,
+      });
+    }
+    const locator = parseMessageLocator(locatorRow.locator_json);
+
+    await withImapClient(account, context, async (client) => {
+      const mailboxes = await client.list();
+      const archivePath = resolveMailboxPath(mailboxes, "archive");
+      const archiveExists = mailboxes.some((mailbox) => mailbox.path === archivePath);
+      if (!archiveExists) {
+        throw new SurfaceError("unsupported", "This IMAP account does not expose an archive mailbox.", {
+          account: account.name,
+          messageRef,
+          threadRef: stored.thread_ref,
+        });
+      }
+      const mailbox = await client.mailboxOpen(locator.mailbox);
+      if (uidValidityString(mailbox) !== locator.uid_validity) {
+        throw new SurfaceError("cache_miss", `IMAP UIDVALIDITY changed for mailbox '${locator.mailbox}'.`, {
+          account: account.name,
+          messageRef,
+          threadRef: stored.thread_ref,
+        });
+      }
+      const moveResult = await client.messageMove(String(locator.uid), archivePath, { uid: true });
+      const newUid = moveResult && moveResult.uidMap ? moveResult.uidMap.get(locator.uid) : undefined;
+      const refreshedThread = await recoverArchivedThreadAfterMove(account, client, archivePath, stored, locator, newUid);
+      const refreshedMessage = refreshedThread?.messages[0];
+      const refreshedThreadLocator = refreshedThread?.locator?.locator as ImapThreadLocator | undefined;
+      const refreshedMessageLocator = refreshedMessage?.locator?.locator as ImapMessageLocator | undefined;
+      const [persisted] = refreshedThread && refreshedMessage && refreshedThreadLocator && refreshedMessageLocator
+        ? persistThreads(account, context, [refreshedThread], {
+          threadRefsByProviderKey: new Map([[imapThreadProviderKey(refreshedThreadLocator), stored.thread_ref]]),
+          messageRefsByProviderKey: new Map([[imapMessageProviderKey(refreshedMessageLocator), messageRef]]),
+          attachmentRefsByProviderKey: buildAttachmentRefOverrides(
+            context,
+            messageRef,
+            refreshedMessageLocator,
+            refreshedMessage.attachments,
+          ),
+        })
+        : [];
+      if (!persisted) {
+        context.db.markThreadArchived(stored.thread_ref);
+      }
+    });
+
+    return buildArchiveEnvelope(account, messageRef, stored.thread_ref);
   }
 
   async markRead(
     account: MailAccount,
-    _messageRefs: string[],
-    _context: ProviderContext,
+    messageRefs: string[],
+    context: ProviderContext,
   ): Promise<MarkMessagesResultEnvelope> {
-    notImplemented("IMAP mark-read is not implemented yet.", account.name);
+    assertWriteAllowed(context.config, account, { to: [], cc: [], bcc: [] }, { disposition: "non_send" });
+    return buildMarkMessagesEnvelope(account, "mark-read", await mutateSeenFlag(account, context, messageRefs, false));
   }
 
   async markUnread(
     account: MailAccount,
-    _messageRefs: string[],
-    _context: ProviderContext,
+    messageRefs: string[],
+    context: ProviderContext,
   ): Promise<MarkMessagesResultEnvelope> {
-    notImplemented("IMAP mark-unread is not implemented yet.", account.name);
+    assertWriteAllowed(context.config, account, { to: [], cc: [], bcc: [] }, { disposition: "non_send" });
+    return buildMarkMessagesEnvelope(account, "mark-unread", await mutateSeenFlag(account, context, messageRefs, true));
   }
 }

--- a/src/providers/imap/adapter.ts
+++ b/src/providers/imap/adapter.ts
@@ -311,7 +311,7 @@ function imapMessageProviderKey(locator: ImapMessageLocator): string {
 function imapAttachmentProviderKey(messageLocator: ImapMessageLocator, attachment: NormalizedAttachmentRecord, index: number): string {
   const checksum = attachment.locator?.locator.checksum;
   if (typeof checksum === "string" && checksum) {
-    return `imap-attachment:${messageLocator.mailbox}:${messageLocator.uid_validity}:${messageLocator.uid}:${checksum}`;
+    return `imap-attachment:${messageLocator.mailbox}:${messageLocator.uid_validity}:${messageLocator.uid}:${index}:${checksum}`;
   }
   return `imap-attachment:${messageLocator.mailbox}:${messageLocator.uid_validity}:${messageLocator.uid}:${attachment.filename}:${index}`;
 }
@@ -1237,7 +1237,7 @@ function attachmentMetas(context: ProviderContext, messageRef: string): Attachme
 function attachmentIdentityKeys(locator: ImapAttachmentLocator): string[] {
   const keys: string[] = [];
   if (locator.checksum) {
-    keys.push(`checksum:${locator.checksum}`);
+    keys.push(`checksum:${locator.index}:${locator.checksum}`);
   }
   keys.push(`position:${locator.index}:${(locator.filename ?? "").trim().toLowerCase()}`);
   return keys;
@@ -1709,6 +1709,7 @@ export const imapAdapterTestHooks = {
   buildSentSearch,
   draftAppendFlags: DRAFT_APPEND_FLAGS,
   filterSentMessagesForQuery,
+  imapAttachmentProviderKey,
   replyReferences,
   resolveMailboxPath,
   sentAppendFlags: SENT_APPEND_FLAGS,

--- a/src/providers/imap/adapter.ts
+++ b/src/providers/imap/adapter.ts
@@ -93,6 +93,12 @@ interface ImapAttachmentLocator {
   filename: string | null;
 }
 
+interface ResolvedComposeEmails {
+  to: string[];
+  cc: string[];
+  bcc: string[];
+}
+
 function sourceInfo(account: MailAccount) {
   return {
     provider: account.provider,
@@ -1546,6 +1552,61 @@ function withoutAccountEmails(emails: string[], selfEmails: Set<string>): string
   return emails.filter((email) => !selfEmails.has(normalizeComparableEmail(email)));
 }
 
+function buildReplyRecipients(input: {
+  replyTo: string[];
+  from: string[];
+  originalTo: string[];
+  inputCc: string[];
+  inputBcc: string[];
+  selfEmails: Set<string>;
+}): ResolvedComposeEmails {
+  let to = normalizeEmailList(withoutAccountEmails(input.replyTo, input.selfEmails));
+  if (to.length === 0) {
+    to = normalizeEmailList(withoutAccountEmails(input.from, input.selfEmails));
+  }
+  if (to.length === 0) {
+    to = normalizeEmailList(withoutAccountEmails(input.originalTo, input.selfEmails));
+  }
+  return {
+    to,
+    cc: normalizeEmailList(input.inputCc),
+    bcc: normalizeEmailList(input.inputBcc),
+  };
+}
+
+function buildReplyAllRecipients(input: {
+  replyTo: string[];
+  from: string[];
+  originalTo: string[];
+  originalCc: string[];
+  inputCc: string[];
+  inputBcc: string[];
+  selfEmails: Set<string>;
+}): ResolvedComposeEmails {
+  let to = normalizeEmailList(withoutAccountEmails(input.replyTo, input.selfEmails));
+  if (to.length === 0) {
+    to = normalizeEmailList(withoutAccountEmails(input.from, input.selfEmails));
+  }
+  if (to.length === 0) {
+    to = normalizeEmailList(withoutAccountEmails(input.originalTo, input.selfEmails));
+  }
+  if (to.length === 0) {
+    to = normalizeEmailList(input.from);
+  }
+
+  const toComparable = new Set(to.map(normalizeComparableEmail));
+  const cc = normalizeEmailList([
+    ...withoutAccountEmails(input.originalTo, input.selfEmails).filter((email) => !toComparable.has(normalizeComparableEmail(email))),
+    ...withoutAccountEmails(input.originalCc, input.selfEmails).filter((email) => !toComparable.has(normalizeComparableEmail(email))),
+    ...input.inputCc,
+  ]);
+  return {
+    to,
+    cc,
+    bcc: normalizeEmailList(input.inputBcc),
+  };
+}
+
 function replyReferences(target: { messageId: string | null; references: string | null }): string | null {
   return target.references
     ? `${target.references}${target.messageId ? ` ${target.messageId}` : ""}`.trim()
@@ -1642,6 +1703,8 @@ async function mutateSeenFlag(
 
 export const imapAdapterTestHooks = {
   archivedThreadMatchesStoredMessage,
+  buildReplyAllRecipients,
+  buildReplyRecipients,
   buildComposeRaw,
   buildSentSearch,
   draftAppendFlags: DRAFT_APPEND_FLAGS,
@@ -1901,15 +1964,14 @@ export class ImapSmtpAdapter implements MailProviderAdapter {
     const selfEmails = accountIdentityEmails(account, context);
     const replyTo = emailsFromAddressObject(target.parsed.replyTo);
     const from = emailsFromAddressObject(target.parsed.from);
-    let to = normalizeEmailList(withoutAccountEmails([...replyTo, ...from], selfEmails));
-    if (to.length === 0) {
-      to = normalizeEmailList(withoutAccountEmails(emailsFromAddressObject(target.parsed.to), selfEmails));
-    }
-    const recipients = {
-      to,
-      cc: normalizeEmailList(input.cc),
-      bcc: normalizeEmailList(input.bcc),
-    };
+    const recipients = buildReplyRecipients({
+      replyTo,
+      from,
+      originalTo: emailsFromAddressObject(target.parsed.to),
+      inputCc: input.cc,
+      inputBcc: input.bcc,
+      selfEmails,
+    });
     if (recipients.to.length === 0) {
       throw new SurfaceError("unsupported", `Message '${messageRef}' does not expose a reply target.`, {
         account: account.name,
@@ -1958,25 +2020,15 @@ export class ImapSmtpAdapter implements MailProviderAdapter {
     const originalTo = emailsFromAddressObject(target.parsed.to);
     const originalCc = emailsFromAddressObject(target.parsed.cc);
 
-    let to = normalizeEmailList(withoutAccountEmails([...replyTo, ...from], selfEmails));
-    if (to.length === 0) {
-      to = normalizeEmailList(withoutAccountEmails(originalTo, selfEmails));
-    }
-    if (to.length === 0) {
-      to = normalizeEmailList(from);
-    }
-
-    const toComparable = new Set(to.map(normalizeComparableEmail));
-    const cc = normalizeEmailList([
-      ...withoutAccountEmails(originalTo, selfEmails).filter((email) => !toComparable.has(normalizeComparableEmail(email))),
-      ...withoutAccountEmails(originalCc, selfEmails).filter((email) => !toComparable.has(normalizeComparableEmail(email))),
-      ...input.cc,
-    ]);
-    const recipients = {
-      to,
-      cc,
-      bcc: normalizeEmailList(input.bcc),
-    };
+    const recipients = buildReplyAllRecipients({
+      replyTo,
+      from,
+      originalTo,
+      originalCc,
+      inputCc: input.cc,
+      inputBcc: input.bcc,
+      selfEmails,
+    });
     if (recipients.to.length === 0) {
       throw new SurfaceError("unsupported", `Message '${messageRef}' does not expose reply-all recipients.`, {
         account: account.name,

--- a/src/providers/imap/adapter.ts
+++ b/src/providers/imap/adapter.ts
@@ -1,0 +1,191 @@
+import type { MailAccount } from "../../contracts/account.js";
+import type {
+  ArchiveResultEnvelope,
+  AttachmentDownloadEnvelope,
+  AttachmentListEnvelope,
+  FetchUnreadQuery,
+  ForwardInput,
+  MarkMessagesResultEnvelope,
+  NormalizedThreadRecord,
+  ReadResultEnvelope,
+  ReplyInput,
+  RsvpResponse,
+  RsvpResultEnvelope,
+  SearchQuery,
+  SendMessageInput,
+  SendResultEnvelope,
+  SentMessageResult,
+  SentQuery,
+} from "../../contracts/mail.js";
+import { SurfaceError, notImplemented } from "../../lib/errors.js";
+import type { AuthStatus, MailProviderAdapter, ProviderContext } from "../types.js";
+import { clearImapSmtpAuthState, readImapSmtpAuthState, writeImapSmtpAuthState } from "./auth.js";
+
+export class ImapSmtpAdapter implements MailProviderAdapter {
+  readonly provider = "imap" as const;
+  readonly transport = "imap-smtp";
+
+  async login(account: MailAccount, context: ProviderContext): Promise<AuthStatus> {
+    if (!context.authLoginOptions) {
+      throw new SurfaceError("invalid_argument", "Missing IMAP/SMTP auth login options.", {
+        account: account.name,
+      });
+    }
+    const state = writeImapSmtpAuthState(account, context, context.authLoginOptions);
+    return {
+      status: "authenticated",
+      detail: `Stored IMAP/SMTP auth for ${state.username} using ${state.imap.host}:${state.imap.port}.`,
+    };
+  }
+
+  async logout(_account: MailAccount, context: ProviderContext): Promise<AuthStatus> {
+    clearImapSmtpAuthState(context);
+    return {
+      status: "unauthenticated",
+      detail: "Removed stored IMAP/SMTP auth for this account.",
+    };
+  }
+
+  async authStatus(account: MailAccount, context: ProviderContext): Promise<AuthStatus> {
+    try {
+      const state = readImapSmtpAuthState(account, context);
+      return {
+        status: "authenticated",
+        detail: `Stored IMAP/SMTP auth for ${state.username} using ${state.imap.host}:${state.imap.port}.`,
+      };
+    } catch (error) {
+      if (error instanceof SurfaceError && error.code === "reauth_required") {
+        return {
+          status: "unauthenticated",
+          detail: error.message,
+        };
+      }
+      throw error;
+    }
+  }
+
+  async search(
+    account: MailAccount,
+    _query: SearchQuery,
+    _context: ProviderContext,
+  ): Promise<NormalizedThreadRecord[]> {
+    notImplemented("IMAP search is not implemented yet.", account.name);
+  }
+
+  async fetchUnread(
+    account: MailAccount,
+    _query: FetchUnreadQuery,
+    _context: ProviderContext,
+  ): Promise<NormalizedThreadRecord[]> {
+    notImplemented("IMAP fetch-unread is not implemented yet.", account.name);
+  }
+
+  async fetchSent(
+    account: MailAccount,
+    _query: SentQuery,
+    _context: ProviderContext,
+  ): Promise<SentMessageResult[]> {
+    notImplemented("IMAP sent-mail lookup is not implemented yet.", account.name);
+  }
+
+  async refreshThread(account: MailAccount, threadRef: string, _context: ProviderContext): Promise<void> {
+    notImplemented(`IMAP thread refresh is not implemented yet for '${threadRef}'.`, account.name);
+  }
+
+  async readMessage(
+    account: MailAccount,
+    messageRef: string,
+    _refresh: boolean,
+    _context: ProviderContext,
+  ): Promise<ReadResultEnvelope> {
+    notImplemented(`IMAP message read is not implemented yet for '${messageRef}'.`, account.name);
+  }
+
+  async listAttachments(
+    account: MailAccount,
+    messageRef: string,
+    _context: ProviderContext,
+  ): Promise<AttachmentListEnvelope> {
+    notImplemented(`IMAP attachment list is not implemented yet for '${messageRef}'.`, account.name);
+  }
+
+  async downloadAttachment(
+    account: MailAccount,
+    messageRef: string,
+    attachmentId: string,
+    _context: ProviderContext,
+  ): Promise<AttachmentDownloadEnvelope> {
+    notImplemented(`IMAP attachment download is not implemented yet for '${messageRef}/${attachmentId}'.`, account.name);
+  }
+
+  async rsvp(
+    account: MailAccount,
+    messageRef: string,
+    _response: RsvpResponse,
+    _context: ProviderContext,
+  ): Promise<RsvpResultEnvelope> {
+    throw new SurfaceError("unsupported", `Generic IMAP RSVP is not supported for '${messageRef}'.`, {
+      account: account.name,
+      messageRef,
+    });
+  }
+
+  async sendMessage(
+    account: MailAccount,
+    _input: SendMessageInput,
+    _context: ProviderContext,
+  ): Promise<SendResultEnvelope> {
+    notImplemented("IMAP/SMTP send is not implemented yet.", account.name);
+  }
+
+  async reply(
+    account: MailAccount,
+    messageRef: string,
+    _input: ReplyInput,
+    _context: ProviderContext,
+  ): Promise<SendResultEnvelope> {
+    notImplemented(`IMAP/SMTP reply is not implemented yet for '${messageRef}'.`, account.name);
+  }
+
+  async replyAll(
+    account: MailAccount,
+    messageRef: string,
+    _input: ReplyInput,
+    _context: ProviderContext,
+  ): Promise<SendResultEnvelope> {
+    notImplemented(`IMAP/SMTP reply-all is not implemented yet for '${messageRef}'.`, account.name);
+  }
+
+  async forward(
+    account: MailAccount,
+    messageRef: string,
+    _input: ForwardInput,
+    _context: ProviderContext,
+  ): Promise<SendResultEnvelope> {
+    notImplemented(`IMAP/SMTP forward is not implemented yet for '${messageRef}'.`, account.name);
+  }
+
+  async archive(
+    account: MailAccount,
+    messageRef: string,
+    _context: ProviderContext,
+  ): Promise<ArchiveResultEnvelope> {
+    notImplemented(`IMAP archive is not implemented yet for '${messageRef}'.`, account.name);
+  }
+
+  async markRead(
+    account: MailAccount,
+    _messageRefs: string[],
+    _context: ProviderContext,
+  ): Promise<MarkMessagesResultEnvelope> {
+    notImplemented("IMAP mark-read is not implemented yet.", account.name);
+  }
+
+  async markUnread(
+    account: MailAccount,
+    _messageRefs: string[],
+    _context: ProviderContext,
+  ): Promise<MarkMessagesResultEnvelope> {
+    notImplemented("IMAP mark-unread is not implemented yet.", account.name);
+  }
+}

--- a/src/providers/imap/auth.test.ts
+++ b/src/providers/imap/auth.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { MailAccount } from "../../contracts/account.js";
+import type { AuthLoginOptions } from "../types.js";
+import { imapAuthTestHooks } from "./auth.js";
+
+function account(): MailAccount {
+  return {
+    account_id: "acc_imap",
+    name: "imap",
+    provider: "imap",
+    transport: "imap-smtp",
+    email: "surface@example.com",
+    created_at: "2026-06-03T12:00:00.000Z",
+    updated_at: "2026-06-03T12:00:00.000Z",
+  };
+}
+
+test("failing password-command errors are redacted", () => {
+  const command = `${process.execPath} -e "console.error('DO_NOT_LEAK_SECRET'); process.exit(7)"`;
+
+  let thrown: unknown;
+  try {
+    imapAuthTestHooks.resolvePassword({ passwordCommand: command } as AuthLoginOptions, account());
+  } catch (error) {
+    thrown = error;
+  }
+
+  assert.ok(thrown instanceof Error);
+  assert.equal(thrown.message, "IMAP/SMTP password command failed.");
+  assert.doesNotMatch(thrown.message, /DO_NOT_LEAK_SECRET/);
+  assert.doesNotMatch(thrown.message, /process\.exit/);
+  assert.doesNotMatch(thrown.message, new RegExp(process.execPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});

--- a/src/providers/imap/auth.ts
+++ b/src/providers/imap/auth.ts
@@ -102,10 +102,10 @@ function readPasswordFromCommand(command: string, account: MailAccount): string 
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 30_000,
     }).replace(/[\r\n]+$/g, "");
-  } catch (error) {
+  } catch {
     throw new SurfaceError(
       "invalid_argument",
-      `IMAP/SMTP password command failed: ${error instanceof Error ? error.message : String(error)}`,
+      "IMAP/SMTP password command failed.",
       { account: account.name },
     );
   }
@@ -220,3 +220,7 @@ export function writeImapSmtpAuthState(
 export function clearImapSmtpAuthState(context: ProviderContext): void {
   rmSync(imapSmtpAuthPath(context), { force: true });
 }
+
+export const imapAuthTestHooks = {
+  resolvePassword,
+};

--- a/src/providers/imap/auth.ts
+++ b/src/providers/imap/auth.ts
@@ -1,0 +1,222 @@
+import { execSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { MailAccount } from "../../contracts/account.js";
+import { SurfaceError } from "../../lib/errors.js";
+import { nowIsoUtc } from "../../lib/time.js";
+import type { AuthLoginOptions, ImapSmtpSecurityMode, ProviderContext } from "../types.js";
+
+export interface ImapSmtpAuthState {
+  version: 1;
+  imap: {
+    host: string;
+    port: number;
+    security: ImapSmtpSecurityMode;
+  };
+  smtp: {
+    host: string;
+    port: number;
+    security: ImapSmtpSecurityMode;
+  };
+  username: string;
+  password: string;
+  updated_at: string;
+}
+
+export function imapSmtpAuthPath(context: ProviderContext): string {
+  return resolve(context.accountPaths.authDir, "imap-smtp.json");
+}
+
+function requireString(
+  options: AuthLoginOptions,
+  field: keyof AuthLoginOptions,
+  flag: string,
+  account: MailAccount,
+): string {
+  const value = options[field];
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  throw new SurfaceError("invalid_argument", `IMAP/SMTP auth login requires ${flag}.`, {
+    account: account.name,
+  });
+}
+
+function requirePort(
+  options: AuthLoginOptions,
+  field: "imapPort" | "smtpPort",
+  flag: string,
+  account: MailAccount,
+): number {
+  const value = options[field];
+  if (typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= 65535) {
+    return value;
+  }
+  throw new SurfaceError("invalid_argument", `IMAP/SMTP auth login requires ${flag} as a TCP port from 1 to 65535.`, {
+    account: account.name,
+  });
+}
+
+function requireSecurity(
+  options: AuthLoginOptions,
+  field: "imapSecurity" | "smtpSecurity",
+  flag: string,
+  account: MailAccount,
+): ImapSmtpSecurityMode {
+  const value = options[field];
+  if (value === "tls" || value === "starttls" || value === "none") {
+    return value;
+  }
+  throw new SurfaceError("invalid_argument", `IMAP/SMTP auth login requires ${flag} as one of: tls, starttls, none.`, {
+    account: account.name,
+  });
+}
+
+function readPasswordFromEnv(envName: string, account: MailAccount): string {
+  const value = process.env[envName];
+  if (value === undefined) {
+    throw new SurfaceError("invalid_argument", `Environment variable '${envName}' is not set.`, {
+      account: account.name,
+    });
+  }
+  return value.replace(/[\r\n]+$/g, "");
+}
+
+function readPasswordFromFile(path: string, account: MailAccount): string {
+  try {
+    return readFileSync(resolve(path), "utf8").replace(/[\r\n]+$/g, "");
+  } catch (error) {
+    throw new SurfaceError(
+      "invalid_argument",
+      `Could not read IMAP/SMTP password file '${path}': ${error instanceof Error ? error.message : String(error)}`,
+      { account: account.name },
+    );
+  }
+}
+
+function readPasswordFromCommand(command: string, account: MailAccount): string {
+  try {
+    return execSync(command, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    }).replace(/[\r\n]+$/g, "");
+  } catch (error) {
+    throw new SurfaceError(
+      "invalid_argument",
+      `IMAP/SMTP password command failed: ${error instanceof Error ? error.message : String(error)}`,
+      { account: account.name },
+    );
+  }
+}
+
+function resolvePassword(options: AuthLoginOptions, account: MailAccount): string {
+  const sources = [
+    options.passwordEnv ? "env" : null,
+    options.passwordFile ? "file" : null,
+    options.passwordCommand ? "command" : null,
+  ].filter(Boolean);
+
+  if (sources.length !== 1) {
+    throw new SurfaceError(
+      "invalid_argument",
+      "IMAP/SMTP auth login requires exactly one of --password-env, --password-file, or --password-command.",
+      { account: account.name },
+    );
+  }
+
+  if (options.passwordEnv) {
+    return readPasswordFromEnv(options.passwordEnv, account);
+  }
+  if (options.passwordFile) {
+    return readPasswordFromFile(options.passwordFile, account);
+  }
+  if (options.passwordCommand) {
+    return readPasswordFromCommand(options.passwordCommand, account);
+  }
+  throw new SurfaceError("invalid_argument", "Missing IMAP/SMTP password source.", {
+    account: account.name,
+  });
+}
+
+function validateAuthState(value: unknown, path: string, account: MailAccount): ImapSmtpAuthState {
+  const state = value as Partial<ImapSmtpAuthState>;
+  if (
+    state.version !== 1
+    || !state.imap?.host
+    || !state.imap?.port
+    || !state.imap?.security
+    || !state.smtp?.host
+    || !state.smtp?.port
+    || !state.smtp?.security
+    || !state.username
+    || typeof state.password !== "string"
+  ) {
+    throw new SurfaceError("invalid_configuration", `IMAP/SMTP auth state at ${path} is incomplete.`, {
+      account: account.name,
+    });
+  }
+  return state as ImapSmtpAuthState;
+}
+
+export function readImapSmtpAuthState(account: MailAccount, context: ProviderContext): ImapSmtpAuthState {
+  const path = imapSmtpAuthPath(context);
+  if (!existsSync(path)) {
+    throw new SurfaceError("reauth_required", `No IMAP/SMTP auth state found for account '${account.name}'.`, {
+      account: account.name,
+    });
+  }
+
+  try {
+    return validateAuthState(JSON.parse(readFileSync(path, "utf8")) as unknown, path, account);
+  } catch (error) {
+    if (error instanceof SurfaceError) {
+      throw error;
+    }
+    throw new SurfaceError(
+      "invalid_configuration",
+      `Could not read IMAP/SMTP auth state from ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      { account: account.name },
+    );
+  }
+}
+
+export function writeImapSmtpAuthState(
+  account: MailAccount,
+  context: ProviderContext,
+  options: AuthLoginOptions,
+): ImapSmtpAuthState {
+  const state: ImapSmtpAuthState = {
+    version: 1,
+    imap: {
+      host: requireString(options, "imapHost", "--imap-host", account),
+      port: requirePort(options, "imapPort", "--imap-port", account),
+      security: requireSecurity(options, "imapSecurity", "--imap-security", account),
+    },
+    smtp: {
+      host: requireString(options, "smtpHost", "--smtp-host", account),
+      port: requirePort(options, "smtpPort", "--smtp-port", account),
+      security: requireSecurity(options, "smtpSecurity", "--smtp-security", account),
+    },
+    username: options.username?.trim() || account.email,
+    password: resolvePassword(options, account),
+    updated_at: nowIsoUtc(),
+  };
+
+  if (!state.password) {
+    throw new SurfaceError("invalid_argument", "IMAP/SMTP password source returned an empty password.", {
+      account: account.name,
+    });
+  }
+
+  mkdirSync(context.accountPaths.authDir, { recursive: true });
+  const path = imapSmtpAuthPath(context);
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  chmodSync(path, 0o600);
+  return state;
+}
+
+export function clearImapSmtpAuthState(context: ProviderContext): void {
+  rmSync(imapSmtpAuthPath(context), { force: true });
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,10 +1,15 @@
 import type { MailAccount } from "../contracts/account.js";
 import { SurfaceError } from "../lib/errors.js";
 import { GmailApiAdapter } from "./gmail/adapter.js";
+import { ImapSmtpAdapter } from "./imap/adapter.js";
 import { OutlookWebPlaywrightAdapter } from "./outlook/adapter.js";
 import type { MailProviderAdapter } from "./types.js";
 
-const providers: MailProviderAdapter[] = [new GmailApiAdapter(), new OutlookWebPlaywrightAdapter()];
+const providers: MailProviderAdapter[] = [
+  new GmailApiAdapter(),
+  new OutlookWebPlaywrightAdapter(),
+  new ImapSmtpAdapter(),
+];
 
 export function resolveProviderAdapter(account: MailAccount): MailProviderAdapter {
   const adapter = providers.find(

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -26,11 +26,27 @@ export interface AuthStatus {
   detail?: string;
 }
 
+export type ImapSmtpSecurityMode = "tls" | "starttls" | "none";
+
+export interface AuthLoginOptions {
+  imapHost: string | undefined;
+  imapPort: number | undefined;
+  imapSecurity: ImapSmtpSecurityMode | undefined;
+  smtpHost: string | undefined;
+  smtpPort: number | undefined;
+  smtpSecurity: ImapSmtpSecurityMode | undefined;
+  username: string | undefined;
+  passwordEnv: string | undefined;
+  passwordFile: string | undefined;
+  passwordCommand: string | undefined;
+}
+
 export interface ProviderContext {
   config: SurfaceConfig;
   paths: SurfacePaths;
   accountPaths: AccountPaths;
   db: SurfaceDatabase;
+  authLoginOptions?: AuthLoginOptions;
 }
 
 export interface MailProviderAdapter {


### PR DESCRIPTION
## Summary

- Add generic `provider=imap` / `transport=imap-smtp` account setup and auth state for standard IMAP + SMTP mailboxes.
- Implement IMAP read paths and actions: search, fetch-unread, thread refresh, read, attachments, sent lookup, mark read/unread, and archive when the provider exposes an archive-like mailbox.
- Implement SMTP-backed send, draft, reply, reply-all, and forward with existing write-safety policy.
- Document the public contract, provider behavior, ADR, README, and Surface skill guidance for generic IMAP/SMTP.
- Keep Gmail, Outlook, and normalized DB schema untouched.

## Live GMX Evidence

Using real `gmx_test` with IMAP enabled and `personal_1` Gmail as the required sender/receiver:

- IMAP auth/status succeeded against `imap.gmx.com:993`.
- Gmail-to-GMX delivery was readable through IMAP; GMX classified Gmail-originated mail as Spam, so tests used explicit mailbox filters.
- Verified search, fetch-unread, thread get, read, mark-read, mark-unread, `read --mark-read`, sync-unread-state, attachment list, and attachment download.
- Verified GMX SMTP send to `personal_1`, sent lookup by recipient/thread, draft creation and Drafts lookup.
- Verified GMX reply and reply-all delivery; reply-all sent copy preserved To/Cc recipients.
- Verified GMX forward delivery to `personal_1`.
- Verified generic IMAP RSVP returns `unsupported` and GMX archive returns `unsupported` because the account exposes no Archive mailbox.

## QA Fixes

- Treat `Reply-To` as authoritative for IMAP reply/reply-all rather than adding `From` as a recipient.
- Redact failed `--password-command` errors so command text/stderr cannot leak into public JSON.
- Added regression tests for both cases.

## Validation

- `npm run check`
- `node --import tsx --test $(find src -name '*.test.ts' -print)` (17 passing tests)
- `npm run build`
- `npm pack --dry-run`
- `git diff --check origin/main...HEAD`
- Protected diff check: no changes under `src/providers/gmail`, `src/providers/outlook`, or `src/state`
- Subagent QA after milestones; final re-review found no remaining must-fix findings

Linear: PER-252
