### PR TITLE
[codex] Add direct IMAP password flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,23 +126,41 @@ client secret at `./client_secret.json` or set `SURFACE_GMAIL_CLIENT_SECRET_FILE
 For generic IMAP/SMTP, `provider=imap` uses the provider's mail server settings
 directly. It does not need a Google Cloud project, OAuth client JSON, Microsoft
 Graph app registration, or browser automation. It does need IMAP settings, SMTP
-settings, a username, and a mailbox or app password from a local secret source.
+settings, a username, and a mailbox or app password.
+
+The direct flag is `--password <password>`. For normal setup, prefer
+`--password-env`, `--password-file`, or `--password-command` so the actual
+password is not written into shell history, process listings, terminal logs, or
+agent transcripts.
 
 GMX example:
 
 ```bash
+set -a
+. ~/.surface-cli/secrets/gmx.env
+set +a
+
 surface auth login gmx \
   --imap-host imap.gmx.com --imap-port 993 --imap-security tls \
   --smtp-host mail.gmx.com --smtp-port 587 --smtp-security starttls \
   --username you@gmx.com \
-  --password-command "security find-generic-password -w -s surface-gmx"
+  --password-env SURFACE_GMX_PASSWORD
 
 surface auth status gmx
+unset SURFACE_GMX_PASSWORD
+```
+
+Where `~/.surface-cli/secrets/gmx.env` is a private file outside the repo, kept
+with permissions such as `chmod 600`, containing:
+
+```bash
+SURFACE_GMX_PASSWORD='your-mailbox-or-app-password'
 ```
 
 For GMX, enable POP3/IMAP in GMX web settings before logging in. Prefer a
-password manager, macOS Keychain, `--password-command`, `--password-env`, or
-`--password-file`; do not put mailbox passwords in the repo or `config.toml`.
+password manager, env var, or private password file; do not put mailbox
+passwords in the repo or `config.toml`, and avoid typing real passwords directly
+with `--password` except for controlled one-off use.
 Surface reads MIME directly over IMAP, so it does not depend on webmail
 "show images" or "trust sender" UI. Remote images are not fetched; message body
 text, links, and MIME attachments can still be read and downloaded.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -103,12 +103,20 @@ IMAP/SMTP auth notes:
   - `--smtp-port <port>`
   - `--smtp-security <tls|starttls|none>`
   - `--username <username>`
-  - exactly one password source: `--password-env <name>`, `--password-file <path>`, or
-    `--password-command <command>`
+  - exactly one password source: `--password <password>`, `--password-env <name>`,
+    `--password-file <path>`, or `--password-command <command>`
+- `--password <password>` treats the flag value as the mailbox/app password directly. It is
+  supported for compatibility and controlled one-off use, but docs and agent workflows should
+  prefer `--password-env`, `--password-file`, or `--password-command` because direct CLI passwords
+  can leak through shell history, process listings, terminal logs, or agent transcripts.
 
 Example GMX-style IMAP/SMTP login:
 
 ```bash
+set -a
+. ~/.surface-cli/secrets/gmx.env
+set +a
+
 surface account add gmx_test --provider imap --email you@gmx.com
 surface auth login gmx_test \
   --imap-host imap.gmx.com \
@@ -118,7 +126,9 @@ surface auth login gmx_test \
   --smtp-port 587 \
   --smtp-security starttls \
   --username you@gmx.com \
-  --password-command "security find-generic-password -w -s surface-gmx-test"
+  --password-env SURFACE_GMX_PASSWORD
+
+unset SURFACE_GMX_PASSWORD
 ```
 
 Generic IMAP/SMTP threading notes:

--- a/docs/decisions/0040-generic-imap-uses-imap-smtp-transport.md
+++ b/docs/decisions/0040-generic-imap-uses-imap-smtp-transport.md
@@ -20,8 +20,11 @@ Surface adds `provider = "imap"` with default `transport = "imap-smtp"`.
 
 `surface auth login <account>` for this transport stores IMAP host/port/security, SMTP
 host/port/security, username, and mailbox/app password in the account auth directory. The password
-must come from a local source such as an environment variable, file, or password-command; it is not
-stored in the public repo, command docs, or `config.toml`.
+can be supplied directly with `--password <password>` or through a local source such as an
+environment variable, file, or password-command. `--password` treats the flag value as the
+mailbox/app password, but documented setup should prefer env/file/command sources because direct
+CLI passwords can leak through shell history, process listings, terminal logs, or agent
+transcripts. The password is not stored in the public repo or `config.toml`.
 
 IMAP locators use the existing provider locator table. Thread and message identity is based on the
 mailbox plus IMAP UID/UIDVALIDITY, with RFC message IDs used as additional metadata when present.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surface-cli",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surface-cli",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surface-cli",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "A lean, local-first mail CLI for Gmail, Outlook, and generic IMAP with a JSON-first contract for automation.",
   "homepage": "https://github.com/VishalJ99/surface-cli",
   "repository": {

--- a/skills/surface-cli/SKILL.md
+++ b/skills/surface-cli/SKILL.md
@@ -83,16 +83,18 @@ surface auth login gmx \
   --imap-host imap.gmx.com --imap-port 993 --imap-security tls \
   --smtp-host mail.gmx.com --smtp-port 587 --smtp-security starttls \
   --username you@gmx.com \
-  --password-command "security find-generic-password -w -s surface-gmx"
+  --password-env SURFACE_GMX_PASSWORD
 ```
 
 For GMX and similar providers, make sure IMAP/POP3 access is enabled in the
 provider web settings before logging in. Generic IMAP login does not need a
 Google Cloud project, OAuth client JSON, Microsoft Graph app registration, or a
 browser session. It does need the provider's IMAP/SMTP settings and a mailbox or
-app password from a local secret source such as `--password-command`,
-`--password-env`, or `--password-file`. Do not ask the user to paste mailbox
-passwords into chat or store them in the repo.
+app password. `--password <password>` is supported and treats the flag value as
+the password directly, but prefer `--password-env`, `--password-file`, or
+`--password-command` because direct CLI passwords can leak through shell
+history, process listings, terminal logs, or agent transcripts. Do not ask the
+user to paste mailbox passwords into chat or store them in the repo.
 
 Local policy lives in:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,10 @@ function normalizeOptionalString(value: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function normalizeOptionalSecret(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
 function normalizeOptionalImapSmtpSecurity(value: unknown): ImapSmtpSecurityMode | undefined {
   const normalized = normalizeOptionalString(value);
   if (!normalized) {
@@ -386,6 +390,7 @@ authCommand
   .addOption(new Option("--smtp-port <port>", "SMTP server port for imap-smtp accounts").argParser(positiveInt))
   .option("--smtp-security <mode>", "SMTP security mode: tls, starttls, or none")
   .option("--username <username>", "Mailbox username for imap-smtp accounts")
+  .option("--password <password>", "Direct mailbox or app password for imap-smtp accounts (less safe)")
   .option("--password-env <name>", "Environment variable containing the mailbox or app password")
   .option("--password-file <path>", "File containing the mailbox or app password")
   .option("--password-command <command>", "Command that prints the mailbox or app password to stdout")
@@ -409,6 +414,7 @@ authCommand
           smtpPort: options.smtpPort,
           smtpSecurity: normalizeOptionalImapSmtpSecurity(options.smtpSecurity),
           username: normalizeOptionalString(options.username),
+          password: normalizeOptionalSecret(options.password),
           passwordEnv: normalizeOptionalString(options.passwordEnv),
           passwordFile: normalizeOptionalString(options.passwordFile),
           passwordCommand: normalizeOptionalString(options.passwordCommand),

--- a/src/providers/imap/auth.test.ts
+++ b/src/providers/imap/auth.test.ts
@@ -33,3 +33,20 @@ test("failing password-command errors are redacted", () => {
   assert.doesNotMatch(thrown.message, /process\.exit/);
   assert.doesNotMatch(thrown.message, new RegExp(process.execPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
+
+test("direct password source returns the password flag value", () => {
+  assert.equal(
+    imapAuthTestHooks.resolvePassword({ password: "mailbox-secret" } as AuthLoginOptions, account()),
+    "mailbox-secret",
+  );
+});
+
+test("password sources are mutually exclusive", () => {
+  assert.throws(
+    () => imapAuthTestHooks.resolvePassword(
+      { password: "mailbox-secret", passwordEnv: "SURFACE_GMX_PASSWORD" } as AuthLoginOptions,
+      account(),
+    ),
+    /exactly one of --password, --password-env, --password-file, or --password-command/,
+  );
+});

--- a/src/providers/imap/auth.ts
+++ b/src/providers/imap/auth.ts
@@ -113,6 +113,7 @@ function readPasswordFromCommand(command: string, account: MailAccount): string 
 
 function resolvePassword(options: AuthLoginOptions, account: MailAccount): string {
   const sources = [
+    options.password !== undefined ? "password" : null,
     options.passwordEnv ? "env" : null,
     options.passwordFile ? "file" : null,
     options.passwordCommand ? "command" : null,
@@ -121,11 +122,14 @@ function resolvePassword(options: AuthLoginOptions, account: MailAccount): strin
   if (sources.length !== 1) {
     throw new SurfaceError(
       "invalid_argument",
-      "IMAP/SMTP auth login requires exactly one of --password-env, --password-file, or --password-command.",
+      "IMAP/SMTP auth login requires exactly one of --password, --password-env, --password-file, or --password-command.",
       { account: account.name },
     );
   }
 
+  if (options.password !== undefined) {
+    return options.password.replace(/[\r\n]+$/g, "");
+  }
   if (options.passwordEnv) {
     return readPasswordFromEnv(options.passwordEnv, account);
   }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -36,6 +36,7 @@ export interface AuthLoginOptions {
   smtpPort: number | undefined;
   smtpSecurity: ImapSmtpSecurityMode | undefined;
   username: string | undefined;
+  password: string | undefined;
   passwordEnv: string | undefined;
   passwordFile: string | undefined;
   passwordCommand: string | undefined;


### PR DESCRIPTION
## Summary
- add `surface auth login --password <password>` for generic IMAP/SMTP accounts
- keep `--password-env`, `--password-file`, and `--password-command` supported and mutually exclusive with direct password
- update README, CLI contract, ADR 0040, and the Surface skill to document direct password support while recommending env/file/command sources for normal setup

## Validation
- `npm install` in the clean worktree after dependency commands initially failed due missing `node_modules`
- `npm run check`
- `node --import tsx --test $(find src -name "*.test.ts" -print)` (20 passing tests)
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`
- `node --import tsx src/cli.ts auth login --help | sed -n '/password/Ip'`\n\nLinear: PER-255